### PR TITLE
Test mapping

### DIFF
--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -243,19 +243,21 @@ def generate_mapping_template(node, node_name="", node_names=None):
 
 
 # Given a mapping csv file, create a scaffold mapping.
-def create_mapping_scaffold(lines):
+def create_mapping_scaffold(lines, test=False):
     props = {}
     for line in lines:
         if line.startswith("#"):
             continue
         if re.match(r"^\s*$", line):
             continue
-        line_match = re.match(r"(##)*(.+?),(.*$)", line.replace("\"", ""))
-        if line_match is not None and line_match.group(1) is None:
-            element = line_match.group(2)
+        line_match = re.match(r"(.+?),(.*$)", line.replace("\"", ""))
+        if line_match is not None:
+            element = line_match.group(1)
             value = ""
-            if line_match.group(3) != "" and not line_match.group(3).startswith("##"):
-                value = line_match.group(3).replace(",", ";")
+            if test:
+                value = "test"
+            if line_match.group(2) != "" and not line_match.group(2).startswith("##"):
+                value = line_match.group(2).replace(",", ";")
             elems = element.replace("*", "").replace("+", "").split(".")
             x = elems.pop(0)
             if x not in props:

--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -190,7 +190,6 @@ def generate_mapping_template(node, node_name="", node_names=None):
         if len(node_names) > 0:
             x = node_names.pop()
             x_match = re.match(r"\"(.+?)\**\",.*", x)
-            print(f"is {x} a header for {node_name}: {x_match}")
             if x_match is not None:
                 if x_match.group(1) in node_name:
                     node_names.append(f"##{x}")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# clinical_ETL 
-[![Build Status](https://travis-ci.com/CanDIG/medidata_mCode_ETL.svg?token=G1SY8JVFAzjkR7ZoffDu&branch=main)](https://travis-ci.com/CanDIG/medidata_mCode_ETL)
+# clinical_ETL_code
 
 Convert patient clinical data to mCode model for Katsu ingestion with Python
 
@@ -126,3 +125,10 @@ Continuous Integration is implemented through Pytest and Travis CI which runs wh
 To run tests manually, enter from command line `$ pytest`
 
 *Note: updated mCodePacket.json files must be pushed for all tests to pass during Travis builds*
+
+## Creating a dummy json file for testing
+You can use a template file (created as described above with `--template`) alone to create a dummy ingest file without actual data. 
+
+`python create_test_mapping.py` creates a file at `mcode_template_testmap.json` that is filled in (without using mapping functions) with placeholder or dummy values. You can specify the placeholder value with the argument `--placeholder`.
+
+This JSON file can be ingested into katsu and compared with the ingested value using https://github.com/CanDIG/candigv2-ingest/blob/main/katsu_validate_dataset.py.

--- a/create_test_mapping.py
+++ b/create_test_mapping.py
@@ -12,8 +12,8 @@ from chord_metadata_service.mcode.schemas import MCODE_SCHEMA
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('template', type=str, help="Path to a template mapping file.")
-    parser.add_argument('--placeholder', type=str, default="abcd")
+    parser.add_argument('--template', type=str, default="mcode_template.csv", help="Path to a template mapping file.")
+    parser.add_argument('--placeholder', type=str, default="abcd", help="Value for placeholder strings.")
     args = parser.parse_args()
     return args
 

--- a/create_test_mapping.py
+++ b/create_test_mapping.py
@@ -1,0 +1,66 @@
+from copy import deepcopy
+import importlib.util
+import json
+import os
+import re
+import yaml
+from CSVConvert import create_mapping_scaffold, generate_mapping_template
+import argparse
+from chord_metadata_service.mcode.schemas import MCODE_SCHEMA
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('template', type=str, help="Path to a template mapping file.")
+    args = parser.parse_args()
+    return args
+
+
+def map_to_mcodepacket(identifier, node, schema):
+    # walk through the provided node of the mcodepacket and fill in the details
+    if "str" in str(type(node)):
+        return schema
+    elif "list" in str(type(node)):
+        new_node = []
+        for i in range(0,len(node)):
+            m = map_to_mcodepacket(identifier, node[i], schema["items"])
+            if "list" in str(type(m)):
+                new_node = m
+            else:
+                new_node.append(m)
+        return new_node
+    elif "dict" in str(type(node)):
+        scaffold = {}
+        for key in node.keys():
+            x = map_to_mcodepacket(identifier, node[key], schema["properties"][key])
+            if x is not None:
+                scaffold[key] = x
+        return scaffold
+
+
+def main(args):
+    template = args.template
+    schema, nn = generate_mapping_template(MCODE_SCHEMA)
+    print(json.dumps(MCODE_SCHEMA, indent=4))
+    if template is not None:
+        with open(template, 'r') as f:
+            lines = f.readlines()
+            mapping_scaffold = create_mapping_scaffold(lines, test=True)
+            # print(json.dumps(mapping_scaffold, indent=4))
+        if mapping_scaffold is None:
+            print("No mapping scaffold was loaded. Either katsu was not found or no schema was specified.")
+            return
+    else:
+        print("A manifest file is required, using the --manifest argument")
+        return
+
+    output_file, ext = os.path.splitext(template)
+
+    mcodepackets = [map_to_mcodepacket(0, deepcopy(mapping_scaffold), MCODE_SCHEMA)]
+
+    with open(f"{output_file}_testmap.json", 'w') as f:    # write to json file for ingestion
+        json.dump(mcodepackets, f, indent=4)
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/create_test_mapping.py
+++ b/create_test_mapping.py
@@ -110,7 +110,7 @@ def main(args):
 
     with open(f"{output_file}_testmap.json", 'w') as f:    # write to json file for ingestion
         json.dump(mcodepackets, f, indent=4)
-
+    print(f"Test mapping saved as {output_file}_testmap.json")
 
 if __name__ == '__main__':
     main(parse_args())

--- a/create_test_mapping.py
+++ b/create_test_mapping.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import yaml
+from datetime import datetime
 from CSVConvert import create_mapping_scaffold, generate_mapping_template
 import argparse
 from chord_metadata_service.mcode.schemas import MCODE_SCHEMA
@@ -12,18 +13,19 @@ from chord_metadata_service.mcode.schemas import MCODE_SCHEMA
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('template', type=str, help="Path to a template mapping file.")
+    parser.add_argument('--placeholder', type=str, default="abcd")
     args = parser.parse_args()
     return args
 
 
-def map_to_mcodepacket(identifier, node, schema):
+def map_to_mcodepacket(placeholder_val, node, schema):
     # walk through the provided node of the mcodepacket and fill in the details
     if "str" in str(type(node)):
-        return schema
+        return pick_value_for_node(placeholder_val, node, schema)
     elif "list" in str(type(node)):
         new_node = []
         for i in range(0,len(node)):
-            m = map_to_mcodepacket(identifier, node[i], schema["items"])
+            m = map_to_mcodepacket(placeholder_val, node[i], schema["items"])
             if "list" in str(type(m)):
                 new_node = m
             else:
@@ -32,16 +34,63 @@ def map_to_mcodepacket(identifier, node, schema):
     elif "dict" in str(type(node)):
         scaffold = {}
         for key in node.keys():
-            x = map_to_mcodepacket(identifier, node[key], schema["properties"][key])
+            x = map_to_mcodepacket(placeholder_val, node[key], schema["properties"][key])
             if x is not None:
                 scaffold[key] = x
         return scaffold
 
 
+def pick_value_for_node(placeholder_val, node, schema):
+    # flatten to only one thing if it's oneOf:
+    if "oneOf" in schema:
+        schema = schema['oneOf'][0]
+        return map_to_mcodepacket(placeholder_val, node, schema)
+    if "anyOf" in schema:
+        schema = schema['anyOf'][0]
+        return map_to_mcodepacket(placeholder_val, node, schema)
+    
+    # break down objects:
+    if "type" in schema:
+        if schema["type"] == "object":
+            obj = {}
+            if "properties" in schema:
+                for k in schema["properties"].keys():
+                    obj[k] = pick_value_for_node(placeholder_val, node, schema["properties"][k])
+            if len(obj.keys()) == 0:
+                obj["value"] = placeholder_val
+            return obj
+        elif schema["type"] == "array":
+            print(schema)
+        elif schema["type"] == "boolean":
+            return True
+        elif schema["type"] == "string":
+            if "enum" in schema:
+                return schema["enum"][0]
+            if "format" in schema and schema["format"] == "date-time":
+                return str(datetime.now())
+            if "description" in schema:
+                # it's useful if there's an example!
+                eg_match = re.match(r".*(e\. *g\. *)(.+?)(\s).*", schema["description"])
+                if eg_match is not None:
+                    return eg_match.group(2)
+                
+                # if it's a timestamp, just stick in a placeholder date:
+                if "date " in schema["description"]:
+                    return "2000-11-01"
+                if "timestamp" in schema["description"]:
+                    return "2000-04-05T14:30"
+                if "CURIE-style" in schema["description"]:
+                    return "UNK:0000"
+            return placeholder_val
+        # else:
+            # return placeholder_val
+    return schema
+
+
 def main(args):
     template = args.template
     schema, nn = generate_mapping_template(MCODE_SCHEMA)
-    print(json.dumps(MCODE_SCHEMA, indent=4))
+    # print(json.dumps(MCODE_SCHEMA, indent=4))
     if template is not None:
         with open(template, 'r') as f:
             lines = f.readlines()
@@ -56,7 +105,7 @@ def main(args):
 
     output_file, ext = os.path.splitext(template)
 
-    mcodepackets = [map_to_mcodepacket(0, deepcopy(mapping_scaffold), MCODE_SCHEMA)]
+    mcodepackets = [map_to_mcodepacket(args.placeholder, deepcopy(mapping_scaffold), MCODE_SCHEMA)]
 
     with open(f"{output_file}_testmap.json", 'w') as f:    # write to json file for ingestion
         json.dump(mcodepackets, f, indent=4)

--- a/create_test_mapping.py
+++ b/create_test_mapping.py
@@ -60,14 +60,15 @@ def pick_value_for_node(placeholder_val, node, schema):
                 obj["value"] = placeholder_val
             return obj
         elif schema["type"] == "array":
-            print(schema)
+            if "items" in schema:
+                return pick_value_for_node(placeholder_val, node, schema["items"])
         elif schema["type"] == "boolean":
             return True
         elif schema["type"] == "string":
             if "enum" in schema:
                 return schema["enum"][0]
             if "format" in schema and schema["format"] == "date-time":
-                return str(datetime.now())
+                return "2022-07-17T17:17:17.085021Z"
             if "description" in schema:
                 # it's useful if there's an example!
                 eg_match = re.match(r".*(e\. *g\. *)(.+?)(\s).*", schema["description"])

--- a/mcode_template.csv
+++ b/mcode_template.csv
@@ -1,5 +1,7 @@
+## schema based on version 2.7.0,
+## directly checked out from https://github.com/CanDIG/katsu.git, commit 6d58fd7225c1c91d8cf428135c4df757cff3003d
 ## mcodepacket element, description (overwrite with mapped element)
-## (.0 is an array element) (* is required) (+ denotes ontology term)
+## (.0 is an array element) (* is required) (+ denotes ontology term),
 "id","##An arbitrary identifier for the mcodepacket."
 ##"subject","##An individual who is a subject of mcodepacket."
 "subject.id*","##A unique researcher-specified identifier for an individual."


### PR DESCRIPTION
Based on a template file, fill in either placeholder or default data into an mcodepacket based on the current version of katsu's mcodepacket schema.

`python create_test_mapping.py` creates a file at mcode_template_testmap.json that can be ingested into katsu and compared with the ingested value using https://github.com/CanDIG/candigv2-ingest/blob/main/katsu_validate_dataset.py.