### PR TITLE
Remove nulls from mapping

### DIFF
--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -271,7 +271,7 @@ def generate_mapping_template(node, node_name="", node_names=None):
 
 def process_mapping(line, test=False):
     """Given a csv mapping line, process into its component pieces."""
-    line_match = re.match(r"(.+?),(.*$)", line)
+    line_match = re.match(r"(.+?),\"*(.*$)\"*", line)
     if line_match is not None:
         element = line_match.group(1)
         value = ""

--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -295,14 +295,15 @@ def create_mapping_scaffold(lines, test=False):
         value, elems = process_mapping(line, test)
         if elems is not None:
             x = elems.pop(0)
-            if x not in props:
-                props[x] = []
-            if len(elems) > 0:
-                props[x].append(".".join(elems)+","+value)
-            elif value != "":
-                props[x].append(value)
-            else:
-                props[x] = []
+            if value is not None and value != "":
+                if x not in props:
+                    props[x] = []
+                if len(elems) > 0:
+                    props[x].append(".".join(elems)+","+value)
+                elif value != "":
+                    props[x].append(value)
+                else:
+                    props[x] = []
         else:
             return line
 

--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -146,6 +146,7 @@ def translate_mapping(identifier, indexed_data, mapping):
 
 
 def process_ref(item):
+    """Given a mapping item, process the reference into the item and the referred sheet."""
     item = item.strip()
     sheets = None
     # are there quotes?


### PR DESCRIPTION
I'm not sure if these have always been there, or if one of my recent changes caused this to happen...

If there are elements in the template that don't have a mapping, sometimes they will end up mapping out with a null value in the scaffold. I think I fixed it so that this doesn't happen anymore. What I mean will be clearer after you run the test.

To test this, go to the https://github.com/CanDIG/mohccn-data repo and run `python clinical_ETL_code/CSVConvert.py --input Synthetic_Clinical_Data_2 --mapping mappings/synthetic_clinical/manifest.yml`. Save off the resulting Synthetic_Clinical_Data_2_map.json. Then update to this branch and run again. Compare the resulting Synthetic_Clinical_Data_2_map.json to the old one. You should find that items that end in nested nulls are gone, but nothing else is.