### PR TITLE
DIG-1267, DIG-1268

### DIFF
--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -40,7 +40,7 @@ def map_data_to_scaffold(node, line):
     """
     mappings.CURRENT_LINE = line
     verbose_print(f"Mapping line '{mappings.CURRENT_LINE}' for {mappings.IDENTIFIER}")
-    curr_id = mappings.peek_at_top_of_stack()
+    curr_id = mappings._peek_at_top_of_stack()
     index_field = curr_id["id"]
     index_value = curr_id["value"]
     identifier = curr_id["indiv"]
@@ -70,7 +70,7 @@ def map_indexed_scaffold(node, line):
     """
     Given a node that is indexed on some array of values, populate the array with the node's values.
     """
-    curr_id = mappings.peek_at_top_of_stack()
+    curr_id = mappings._peek_at_top_of_stack()
     identifier = curr_id["indiv"]
     stack_index_value = curr_id["value"]
     stack_index_field, stack_index_sheets = find_sheets_with_field(curr_id["id"])
@@ -102,11 +102,11 @@ def map_indexed_scaffold(node, line):
     verbose_print(f"Processing over index values {index_values}")
     for i in index_values:
         verbose_print(f"Applying {i} to {line}")
-        mappings.push_to_stack(f'"{index_sheets[0]}".{index_field}', i, identifier)
+        mappings._push_to_stack(f'"{index_sheets[0]}".{index_field}', i, identifier)
         sub_res = map_data_to_scaffold(node["NODES"], f"{line}.INDEX")
         if sub_res is not None:
             result.append(map_data_to_scaffold(node["NODES"], f"{line}.INDEX"))
-        mappings.pop_from_stack()
+        mappings._pop_from_stack()
     if len(result) == 0:
         return None
     return result
@@ -174,7 +174,7 @@ def populate_data_for_params(identifier, index_field, index_value, params):
     values for each parameter.
     If index_field is not None, create an INDEX key that lists all the possible values that could use
     """
-    curr_id = mappings.peek_at_top_of_stack()
+    curr_id = mappings._peek_at_top_of_stack()
     stack_index_field, stack_index_sheets = find_sheets_with_field(curr_id["id"])
     stack_index_value = curr_id["value"]
 
@@ -330,7 +330,7 @@ def process_data(raw_csv_dfs):
             for k in row.keys():
                 merged_dict[i][k.strip()] = [row[k]]
             while len(row_to_merge) > 0:  # there are still entries to merge
-                mappings.warn(f"Duplicate row for {merged_dict[i][identifier][0]} in {page}")
+                mappings._warn(f"Duplicate row for {merged_dict[i][identifier][0]} in {page}")
                 row = row_to_merge.pop(0)
                 for k in row.keys():
                     merged_dict[i][k.strip()].append(row[k])
@@ -614,7 +614,7 @@ def main(args):
     # if verbose flag is set, warn if column name is present in multiple sheets:
     for col in mappings.INDEXED_DATA["columns"]:
         if col != mappings.IDENTIFIER_FIELD and len(mappings.INDEXED_DATA["columns"][col]) > 1:
-            mappings.warn(f"Column name {col} present in multiple sheets: {', '.join(mappings.INDEXED_DATA['columns'][col])}")
+            mappings._warn(f"Column name {col} present in multiple sheets: {', '.join(mappings.INDEXED_DATA['columns'][col])}")
 
     # warn if any template lines map the same column to multiple lines:
     scan_template_for_duplicate_mappings(template_lines)
@@ -636,11 +636,11 @@ def main(args):
     for indiv in mappings.INDEXED_DATA["individuals"]:
         print(f"Creating packet for {indiv}")
         mappings.IDENTIFIER = indiv
-        mappings.push_to_stack(None, None, indiv)
+        mappings._push_to_stack(None, None, indiv)
         packets.append(map_data_to_scaffold(deepcopy(mapping_scaffold), "DONOR"))
-        if mappings.pop_from_stack() is None:
+        if mappings._pop_from_stack() is None:
             raise Exception(f"Stack popped too far!\n{mappings.IDENTIFIER_FIELD}: {mappings.IDENTIFIER}")
-        if mappings.pop_from_stack() is not None:
+        if mappings._pop_from_stack() is not None:
             raise Exception(f"Stack not empty\n{mappings.IDENTIFIER_FIELD}: {mappings.IDENTIFIER}\n {mappings.INDEX_STACK}")
 
     with open(f"{output_file}_indexed.json", 'w') as f:

--- a/README.md
+++ b/README.md
@@ -79,10 +79,9 @@ options:
   --out OUT   name of output file; csv extension will be added. Default is template
 
 ```
+Each line in the mapping template will have a suggested mapping function to map a field on an input sheet to a field in the schema. Replace the generic sheet names with your sheet names. You may need to replace suggested field names with your own field names, if they differ.
 
-For each line in the mapping template, specify any mapping required to convert your input data to the align with the schema. See the [mapping instructions](mapping_functions.md) for detailed documentation on filling out the template.
-
-**Note**: If your input data aligns perfectly with the schema (the column names are exact and unambiguous, and the field data matches the format specified by the schema), you do not need to modify the entry for that field.
+If your data do not map in the same way as the suggested mapping functions, you may need to write your own mapping functions. See the [mapping instructions](mapping_functions.md) for detailed documentation on writing your own mapping functions.
 
 **Note**: Do not edit, delete, or re-order the template lines, except to add mapping functions after the comma in each line.
 

--- a/generate_schema.py
+++ b/generate_schema.py
@@ -37,7 +37,7 @@ def main(args):
 
     with open(outputfile, 'w') as f:  # write to csv file for mapping
         f.write(metadata)
-        f.write("## mohpacket element, description (overwrite with mapped element)\n")
+        f.write("## mohpacket element, mapping method\n")
         # f.write("## (.INDEX is an array element) (* is required) (+ denotes ontology term),\n")
         for nn in node_names:
             f.write(f"{nn}\n")

--- a/mappings.py
+++ b/mappings.py
@@ -26,18 +26,15 @@ def date(data_values):
     if raw_date is None:
         return None
     for date in raw_date:
-        try:
-            d = dateparser.parse(date, settings={'TIMEZONE': 'UTC'})
-            dates.append(d.date().isoformat())
-        except Exception as e:
-            raise MappingError(f"error in date({raw_date}): {type(e)} {e}")
+        dates.append(_parse_date(date).date().isoformat())
     return dates
+
 
 # Single date
 def single_date(data_values):
-    dates = date(data_values)
-    if len(dates) > 0:
-        return dates[0]
+    val = single_val(data_values)
+    if val is not None:
+        return _parse_date(val)
     return None
 
 
@@ -201,4 +198,12 @@ def _is_null(cell):
         return True
     return False
 
-
+# Convenience function to parse dates to ISO format
+def _parse_date(date_string):
+    if any(char in '0123456789' for char in date_string):
+        try:
+            d = dateparser.parse(date_string, settings={'TIMEZONE': 'UTC'})
+            return d.date().isoformat()
+        except Exception as e:
+            raise MappingError(f"error in date({date_string}): {type(e)} {e}")
+    return date_string

--- a/mappings.py
+++ b/mappings.py
@@ -11,51 +11,12 @@ INDEXED_DATA = None
 CURRENT_LINE = ""
 
 
-def warn(message):
-    global VERBOSE
-    global IDENTIFIER
-    if VERBOSE:
-        print(f"WARNING for {IDENTIFIER_FIELD}={IDENTIFIER}: {message}")
-
-
 class MappingError(Exception):
     def __init__(self, value):
         self.value = value
 
     def __str__(self):
         return repr(f"Check the values for {IDENTIFIER} in {IDENTIFIER_FIELD}: {self.value}")
-
-
-def push_to_stack(id, value, indiv):
-    INDEX_STACK.append(
-        {
-            "id": id,
-            "value": value,
-            "indiv": indiv
-        }
-    )
-    if VERBOSE:
-        print(f"Pushed to stack: {INDEX_STACK}")
-
-
-def pop_from_stack():
-    if VERBOSE:
-        print("Popped from stack")
-    if len(INDEX_STACK) > 0:
-        return INDEX_STACK.pop()
-    else:
-        return None
-
-
-def peek_at_top_of_stack():
-    val = INDEX_STACK[-1]
-    if VERBOSE:
-        print(json.dumps(val, indent=2))
-    return {
-        "id": val["id"],
-        "value": val["value"],
-        "indiv": val["indiv"]
-    }
 
 
 # Format a date field to ISO standard
@@ -83,10 +44,10 @@ def single_date(data_values):
 # Returns a boolean based on whether or not the key in the mapping has a value
 def has_value(data_values):
     if len(data_values.keys()) == 0:
-        warn(f"no values passed in")
+        _warn(f"no values passed in")
     else:
         key = list(data_values.keys())[0]
-        if not is_null(data_values[key]):
+        if not _is_null(data_values[key]):
             return True
     return False
 
@@ -147,13 +108,6 @@ def flat_list_val(data_values):
     return all_items
 
 
-# Convenience function to convert nan to boolean
-def is_null(cell):
-    if cell == 'nan' or cell is None or cell == '':
-        return True
-    return False
-
-
 # Convert various responses to boolean
 def boolean(data_values):
     cell = single_val(data_values)
@@ -200,3 +154,51 @@ def indexed_on(data_values):
         if i is not None and str(i).lower() != 'nan':
             final.append(i)
     return final
+
+
+def _warn(message):
+    global VERBOSE
+    global IDENTIFIER
+    if VERBOSE:
+        print(f"WARNING for {IDENTIFIER_FIELD}={IDENTIFIER}: {message}")
+
+
+def _push_to_stack(id, value, indiv):
+    INDEX_STACK.append(
+        {
+            "id": id,
+            "value": value,
+            "indiv": indiv
+        }
+    )
+    if VERBOSE:
+        print(f"Pushed to stack: {INDEX_STACK}")
+
+
+def _pop_from_stack():
+    if VERBOSE:
+        print("Popped from stack")
+    if len(INDEX_STACK) > 0:
+        return INDEX_STACK.pop()
+    else:
+        return None
+
+
+def _peek_at_top_of_stack():
+    val = INDEX_STACK[-1]
+    if VERBOSE:
+        print(json.dumps(val, indent=2))
+    return {
+        "id": val["id"],
+        "value": val["value"],
+        "indiv": val["indiv"]
+    }
+
+
+# Convenience function to convert nan to boolean
+def _is_null(cell):
+    if cell == 'nan' or cell is None or cell == '':
+        return True
+    return False
+
+

--- a/mohschema.py
+++ b/mohschema.py
@@ -160,6 +160,7 @@ class mohschema:
         # otherwise, single_val
         result = []
         index_stack = []
+        sheet_stack = []
         for i in range(0, len(template)):
             # work with line w/o comma
             x = template[i]
@@ -176,10 +177,12 @@ class mohschema:
                 num_indices = field_bits.count("INDEX")
                 if len(index_stack) > num_indices:
                     index_stack = index_stack[0:num_indices]
+                    sheet_stack = sheet_stack[0:num_indices]
 
                 if field_bits[-1] == "INDEX":
                     # base case: assume that the index_value is the last bit before the index
                     data_value = field_bits[len(field_bits)-2]
+                    sheet_stack.append(f"{data_value.upper()}_SHEET")
 
                     # next case: data value could be the the next line's last bit:
                     # prev: primary_site.INDEX
@@ -229,15 +232,17 @@ class mohschema:
                             index_stack.append(data_value)
                             if len(index_stack) > 1:
                                 data_value = index_stack[-2]
-                    x += f" {{indexed_on({data_value})}}"
+                    else:
+                        sheet_stack.pop()
+                    x += f" {{indexed_on({sheet_stack[-1]}.{data_value})}}"
                 elif field_bits[-1].endswith("date") or field_bits[-1].startswith("date"):
-                    x += f" {{single_date({data_value})}}"
+                    x += f" {{single_date({sheet_stack[-1]}.{data_value})}}"
                 elif field_bits[-1].startswith("is_") or field_bits[-1].startswith("has_"):
-                    x += f" {{boolean({data_value})}}"
+                    x += f" {{boolean({sheet_stack[-1]}.{data_value})}}"
                 elif field_bits[-1].startswith("number_") or field_bits[-1].startswith("age_") or "_per_" in field_bits[-1]:
-                    x += f" {{integer({data_value})}}"
+                    x += f" {{integer({sheet_stack[-1]}.{data_value})}}"
                 else:
-                    x += f" {{single_val({data_value})}}"
+                    x += f" {{single_val({sheet_stack[-1]}.{data_value})}}"
                 result.append(x)
         return result
 

--- a/mohschema.py
+++ b/mohschema.py
@@ -211,30 +211,37 @@ class mohschema:
                             if field not in prev_line:
                                 prev_match = re.match(r"(.+),", prev_line)
                                 prev_bits = prev_match.group(1).split(".")
-                                # if prev_bits does not end on INDEX, needs to be trimmed back before its last INDEX:
-                                if prev_bits[-1] != "INDEX":
-                                    while len(prev_bits) > 0:
-                                        if prev_bits[-1] != "INDEX":
-                                            prev_bits.pop()
-                                        else:
+
+                                # if the previous line has more indices than we have now, we have to trim the index_stack.
+                                if prev_bits.count("INDEX") >= num_indices:
+                                    # if prev_bits does not end on INDEX, needs to be trimmed back to its last INDEX:
+                                    if prev_bits[-1] != "INDEX":
+                                        while len(prev_bits) > 0:
+                                            if prev_bits[-1] != "INDEX":
+                                                prev_bits.pop()
+                                            elif prev_bits.count("INDEX") > num_indices:
+                                                prev_bits.pop()
+                                            else:
+                                                break
+
+                                    # we need to figure out just how far back these differ:
+                                    count = 0
+                                    while 1:
+                                        # if this is now the same, we're done
+                                        if (".".join(prev_bits) == ".".join(field_bits)):
                                             break
-                                # bounce off the last two bits from field_bits and one from the stack
-                                done = False
-                                count = 0
-                                while 1:
-                                    if len(field_bits) == 0:
-                                        count = 0
-                                        break
-                                    # if this is now the same, we're done
-                                    if (".".join(prev_bits) == ".".join(field_bits)):
-                                        break
-                                    if ".".join(prev_bits) not in ".".join(field_bits):
                                         count += 1
-                                        break
-                                    field_bits.pop()
-                                    field_bits.pop()
-                                for i in range(0, count):
-                                    index_stack.pop()
+                                        # bounce off the last two bits from field_bits and prev_bits
+                                        field_bits.pop()
+                                        field_bits.pop()
+                                        prev_bits.pop()
+                                        prev_bits.pop()
+
+                                    # pop off {count} from index_stack, but stop as soon as we have fewer than the number of indices
+                                    for i in range(0, count):
+                                        if len(index_stack) < num_indices:
+                                            break
+                                        index_stack.pop()
 
                         # this should be added to the stack, but not if the value is "INDEX"
                         if index_value != "INDEX":

--- a/mohschema.py
+++ b/mohschema.py
@@ -78,7 +78,7 @@ class mohschema:
         # create the template for the schema_name schema
         self.scaffold = self.generate_schema_scaffold(self.schema[self.schema_name])
         # print(json.dumps(self.scaffold, indent=4))
-        _, raw_template = self.generate_mapping_template(self.scaffold)
+        _, raw_template = self.generate_mapping_template(self.scaffold, node_name="DONOR.INDEX")
 
         # add default mapping functions:
         self.template = self.add_default_mappings(raw_template)

--- a/mohschema.py
+++ b/mohschema.py
@@ -179,10 +179,10 @@ class mohschema:
                     index_stack = index_stack[0:num_indices]
                     sheet_stack = sheet_stack[0:num_indices]
 
-                if field_bits[-1] == "INDEX":
+                if data_value == "INDEX":
                     # base case: assume that the index_value is the last bit before the index
-                    data_value = field_bits[len(field_bits)-2]
-                    sheet_stack.append(f"{data_value.upper()}_SHEET")
+                    index_value = field_bits[len(field_bits)-2]
+                    sheet_stack.append(f"{index_value.upper()}_SHEET")
 
                     # next case: data value could be the the next line's last bit:
                     # prev: primary_site.INDEX
@@ -193,7 +193,7 @@ class mohschema:
                     next_bits = next_match.group(1).split(".")
                     if field in next_line:
                         # if the next line is a nested version of field, we need to think about the stack
-                        data_value = next_bits[-1]
+                        index_value = next_bits[-1]
 
                         # but...do we need to un-nest?
                         # this index is NOT a nested entry of the prev one; we need to figure out how far back to un-nest.
@@ -228,18 +228,18 @@ class mohschema:
                                     index_stack.pop()
 
                         # this should be added to the stack, but not if the value is "INDEX"
-                        if data_value != "INDEX":
-                            index_stack.append(data_value)
+                        if index_value != "INDEX":
+                            index_stack.append(index_value)
                             if len(index_stack) > 1:
-                                data_value = index_stack[-2]
+                                index_value = index_stack[-2]
                     else:
                         sheet_stack.pop()
-                    x += f" {{indexed_on({sheet_stack[-1]}.{data_value})}}"
-                elif field_bits[-1].endswith("date") or field_bits[-1].startswith("date"):
+                    x += f" {{indexed_on({sheet_stack[-1]}.{index_value})}}"
+                elif data_value.endswith("date") or data_value.startswith("date"):
                     x += f" {{single_date({sheet_stack[-1]}.{data_value})}}"
-                elif field_bits[-1].startswith("is_") or field_bits[-1].startswith("has_"):
+                elif data_value.startswith("is_") or data_value.startswith("has_"):
                     x += f" {{boolean({sheet_stack[-1]}.{data_value})}}"
-                elif field_bits[-1].startswith("number_") or field_bits[-1].startswith("age_") or "_per_" in field_bits[-1]:
+                elif data_value.startswith("number_") or data_value.startswith("age_") or "_per_" in data_value:
                     x += f" {{integer({sheet_stack[-1]}.{data_value})}}"
                 else:
                     x += f" {{single_val({sheet_stack[-1]}.{data_value})}}"

--- a/mohschema.py
+++ b/mohschema.py
@@ -182,6 +182,15 @@ class mohschema:
                 if data_value == "INDEX":
                     # base case: assume that the index_value is the last bit before the index
                     index_value = field_bits[len(field_bits)-2]
+
+                    # clean up the sheet stack: are the last sheets still involved?
+                    if len(sheet_stack) > 1:
+                        while 1:
+                            last_sheet = sheet_stack.pop()
+                            if last_sheet == "DONOR_SHEET" or last_sheet.replace("_SHEET", "").lower() in field:
+                                sheet_stack.append(last_sheet)
+                                break
+
                     sheet_stack.append(f"{index_value.upper()}_SHEET")
 
                     # next case: data value could be the the next line's last bit:

--- a/test_data_ingest.py
+++ b/test_data_ingest.py
@@ -5,7 +5,7 @@ import mappings
 raw_csvs, output_file = CSVConvert.ingest_raw_data("test_data/pytest_data_v2.xlsx", [])
 mappings.IDENTIFIER_FIELD =  "Subject"
 mappings.INDEXED_DATA = CSVConvert.process_data(raw_csvs)
-mappings.push_to_stack(None, None, mappings.IDENTIFIER)
+mappings._push_to_stack(None, None, mappings.IDENTIFIER)
 
 def test_single_val():
     mappings.IDENTIFIER = "ABC-01-03"

--- a/validate_coverage.py
+++ b/validate_coverage.py
@@ -67,7 +67,7 @@ def parse_args():
 # def check_completeness(raw_csv_dfs, schema):
 #     mappings.INDEXED_DATA = CSVConvert.process_data(raw_csv_dfs)
 #     mappings.IDENTIFIER = mappings.INDEXED_DATA["individuals"][0]
-#     mappings.push_to_stack(None, None, mappings.IDENTIFIER)
+#     mappings._push_to_stack(None, None, mappings.IDENTIFIER)
 #
 #     # expected mapping
 #     expected_flattened = schema.template


### PR DESCRIPTION
DIG-1267: Making the template even more fulsome and self-explanatory:
* template generation now includes DONOR.INDEX at the front, so that the mapper can see that all entries are nested inside a DonorWithClinicalData object
* each mapping defaults to a SHEET_NAME.field_name format, with the probable sheet name filled in. Mappers can do a global find/replace to the actual name of the sheet.

DIG-1268: Making the distinction between mapping methods and internal (or convenience) methods more clear in mappings.py
* prepended an underscore to the names of internal methods, to make it clearer that mappers shouldn't use them in their mappings.
* also did a bonus fix for date parsing: don't try to convert strings with no numerals in them to dates.

Test by generating a template with `python generate_schema.py`. You should see that the indexed_on defaults should map to a particular sheet's value and that sheet/value combination should make sense for that nested object.

There should be no visible changes to the other fix: CSVConvert should work as before, maybe a little faster.