### PR TITLE
HOTFIX: Missing format string

### DIFF
--- a/mohschema.py
+++ b/mohschema.py
@@ -699,5 +699,5 @@ class mohschema:
                 if f"{staging_type}_{f}" not in map_json:
                     warn(f"{staging_type}_{f} is required if {staging_type}_tumour_staging_system is AJCC")
         else:
-            if "{staging_type}_stage_group" not in map_json:
+            if f"{staging_type}_stage_group" not in map_json:
                 warn(f"{staging_type}_stage_group is required for {staging_type}_tumour_staging_system {map_json[f'{staging_type}_tumour_staging_system']}")


### PR DESCRIPTION
- Line 702 in mohschema was a regular string instead of a formatted one, which caused validations to fail