### PR TITLE
Hotfix for treatment_type missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,15 @@ You'll need to create a mapping template that defines which mapping functions (i
 If you're generating a mapping for the current MoH model, you can use the pre-generated `moh_template.csv` file. This file is modified from the auto-generated template to update a few fields that require specific handling.
 
 <details>
+<summary>Updating the moh_template.csv file</summary>
+If the MoH model changes in katsu, the GitHub Action check "Compare moh_template.csv" will fail.
+
+Run the `update_moh_template.sh` script to see what's changed in `test_data/moh_diffs.txt`. Update `moh_template.csv` to reconcile any differences, then re-run `update_moh_template.sh`. Commit any changes in both `moh_template.csv` and `test_data/moh_diffs.txt`.
+</details>
+
+<details>
 <summary>Generating a template from a different schema</summary>
-The `generate_template.py` script will generate a template file based an openapi.yaml file.
+The `generate_schema.py` script will generate a template file based an openapi.yaml file.
 
 ```
 $ python generate_schema.py -h

--- a/moh_template.csv
+++ b/moh_template.csv
@@ -94,7 +94,7 @@ DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX, {indexed_
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_modality, {single_val(RADIATIONS_SHEET.radiation_therapy_modality)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_type, {single_val(RADIATIONS_SHEET.radiation_therapy_type)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.anatomical_site_irradiated, {single_val(RADIATIONS_SHEET.anatomical_site_irradiated)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_fractions, {single_val(RADIATIONS_SHEET.radiation_therapy_fractions)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_fractions, {integer(RADIATIONS_SHEET.radiation_therapy_fractions)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_dosage, {integer(RADIATIONS_SHEET.radiation_therapy_dosage)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_boost, {boolean(RADIATIONS_SHEET.radiation_boost)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.reference_radiation_treatment_id, {single_val(RADIATIONS_SHEET.reference_radiation_treatment_id)}

--- a/mohschema.py
+++ b/mohschema.py
@@ -312,23 +312,24 @@ class MoHSchema(BaseSchema):
         for prop in map_json:
             match prop:
                 case "treatment_type":
-                    for type in map_json["treatment_type"]:
-                        match type:
-                            case "Chemotherapy":
-                                if "chemotherapies" not in map_json:
-                                    self.warn("treatment type Chemotherapy should have one or more chemotherapies submitted")
-                            case "Hormonal therapy":
-                                if "hormone_therapies" not in map_json:
-                                    self.warn("treatment type Hormonal therapy should have one or more hormone_therapies submitted")
-                            case "Immunotherapy":
-                                if "immunotherapies" not in map_json:
-                                    self.warn("treatment type Immunotherapy should have one or more immunotherapies submitted")
-                            case "Radiation therapy":
-                                if "radiations" not in map_json:
-                                    self.warn("treatment type Radiation therapy should have one or more radiation submitted")
-                            case "Surgery":
-                                if "surgeries" not in map_json:
-                                    self.warn("treatment type Surgery should have one or more surgery submitted")
+                    if map_json["treatment_type"] is not None:
+                        for type in map_json["treatment_type"]:
+                            match type:
+                                case "Chemotherapy":
+                                    if "chemotherapies" not in map_json:
+                                        self.warn("treatment type Chemotherapy should have one or more chemotherapies submitted")
+                                case "Hormonal therapy":
+                                    if "hormone_therapies" not in map_json:
+                                        self.warn("treatment type Hormonal therapy should have one or more hormone_therapies submitted")
+                                case "Immunotherapy":
+                                    if "immunotherapies" not in map_json:
+                                        self.warn("treatment type Immunotherapy should have one or more immunotherapies submitted")
+                                case "Radiation therapy":
+                                    if "radiations" not in map_json:
+                                        self.warn("treatment type Radiation therapy should have one or more radiation submitted")
+                                case "Surgery":
+                                    if "surgeries" not in map_json:
+                                        self.warn("treatment type Surgery should have one or more surgery submitted")
 
 
     def validate_chemotherapies(self, map_json):

--- a/test_data/moh_diffs.txt
+++ b/test_data/moh_diffs.txt
@@ -32,10 +32,12 @@
 ---
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.immunotherapies.INDEX.prescribed_cumulative_drug_dose, {integer(IMMUNOTHERAPIES_SHEET.prescribed_cumulative_drug_dose)}
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.immunotherapies.INDEX.actual_cumulative_drug_dose, {integer(IMMUNOTHERAPIES_SHEET.actual_cumulative_drug_dose)}
-97,98c98,99
+96,98c97,99
+< DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_fractions, {single_val(RADIATIONS_SHEET.radiation_therapy_fractions)}
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_dosage, {single_val(RADIATIONS_SHEET.radiation_therapy_dosage)}
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_boost, {single_val(RADIATIONS_SHEET.radiation_boost)}
 ---
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_fractions, {integer(RADIATIONS_SHEET.radiation_therapy_fractions)}
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_dosage, {integer(RADIATIONS_SHEET.radiation_therapy_dosage)}
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_boost, {boolean(RADIATIONS_SHEET.radiation_boost)}
 112,114c113,115

--- a/update_moh_template.sh
+++ b/update_moh_template.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+
+python generate_schema.py --out tmp_template
+diff tmp_template.csv moh_template.csv > test_data/moh_diffs.txt
+bytes=$(head -5 test_data/moh_diffs.txt | wc -c)
+dd if=test_data/moh_diffs.txt  bs="$bytes" skip=1 conv=notrunc of=test_data/moh_diffs.txt
+rm tmp_template.csv


### PR DESCRIPTION
Even though treatment_type is Required, we should be able to handle it as missing.

I also missed that radiation_therapy_fractions is an integer in the moh model, so I updated the moh_template and the diff.

I then realized that I didn't explain how to check to see if that update should happen, so I put in a convenience script to update the moh_template, and updated the README to explain how to know if you need to update and how to update.