### PR TITLE
Don't add required_but_missing fields to failure list

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -336,7 +336,7 @@ class BaseSchema:
                 }
             self.statistics["required_but_missing"][schema_name][f]["total"] += 1
             if f not in map_json:
-                self.warn(f"{f} required for {schema_name}")
+                # self.warn(f"{f} required for {schema_name}")
                 self.statistics["required_but_missing"][schema_name][f]["missing"] += 1
                 if case not in self.statistics["cases_missing_data"]:
                     self.statistics["cases_missing_data"].append(case)

--- a/test_data_ingest.py
+++ b/test_data_ingest.py
@@ -101,7 +101,7 @@ def test_donor_2(packets):
 def test_validation(packets, schema):
     schema.validate_ingest_map({"donors": packets})
     print(schema.validation_failures)
-    assert len(schema.validation_failures) == 9
+    assert len(schema.validation_failures) == 8
     # should be the following 9 failures:
     # DONOR_5: cause_of_death required if is_deceased = Yes
     # DONOR_5: date_of_death required if is_deceased = Yes
@@ -109,7 +109,6 @@ def test_validation(packets, schema):
     # DONOR_5 > PD_5 > SPECIMEN_6: Tumour specimens require a reference_pathology_confirmed_diagnosis
     # DONOR_5 > PD_5 > TR_5 > Radiation 1: Only one radiation is allowed per treatment
     # DONOR_5 > PD_5 > TR_5 > Radiation 1: reference_radiation_treatment_id required if radiation_boost = Yes
-    # DONOR_5 > PD_5 > TR_10: response_to_treatment required for treatments
     # DONOR_5 > PD_5 > TR_10: treatment type Immunotherapy should have one or more immunotherapies submitted
     # DONOR_6 > PD_6 > TR_9 > Surgery 0: submitter_specimen_id SPECIMEN_43 does not correspond to one of the available specimen_ids ['SPECIMEN_3']
 


### PR DESCRIPTION
Instead of adding required_but_missing fields to the validation failures list, only add them to the statistics>required_but_missing list.