### PR TITLE
DIG-1346: distinguish between errors and warnings

### DIFF
--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -650,6 +650,9 @@ def csv_convert(input_path, manifest_file, verbose=False):
     with open(f"{mappings.OUTPUT_FILE}_map.json", 'w') as f:    # write to json file for ingestion
         json.dump(result, f, indent=4)
 
+    if len(result["validation_warnings"]) > 0:
+        print("\n\nWARNING: Your data is missing required data for the MoHCCN data model! The following problems were found:")
+        print("\n".join(result["validation_warnings"]))
     if len(result["validation_errors"]) > 0:
         print("\n\nWARNING: Your data is not valid for the MoHCCN data model! The following errors were found:")
         print("\n".join(result["validation_errors"]))

--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -644,7 +644,8 @@ def csv_convert(input_path, manifest_file, verbose=False):
 
     # add validation data:
     schema.validate_ingest_map(result)
-    result["validation_errors"] = schema.validation_warnings
+    result["validation_errors"] = schema.validation_errors
+    result["validation_warnings"] = schema.validation_warnings
     result["statistics"] = schema.statistics
     with open(f"{mappings.OUTPUT_FILE}_map.json", 'w') as f:    # write to json file for ingestion
         json.dump(result, f, indent=4)

--- a/CSVConvert.py
+++ b/CSVConvert.py
@@ -644,7 +644,7 @@ def csv_convert(input_path, manifest_file, verbose=False):
 
     # add validation data:
     schema.validate_ingest_map(result)
-    result["validation_errors"] = schema.validation_failures
+    result["validation_errors"] = schema.validation_warnings
     result["statistics"] = schema.statistics
     with open(f"{mappings.OUTPUT_FILE}_map.json", 'w') as f:    # write to json file for ingestion
         json.dump(result, f, indent=4)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ python CSVConvert.py [-h] [--input INPUT] [--manifest manifest_file] [--test] 
 
 The output packets (`INPUT_map.json` and `INPUT_indexed.json`) will be in the parent of the `INPUT` directory / file.
 
-Validation will automatically be run after the conversion is complete. Any validation errors will be reported both on the command line and as part of the `INPUT_map.json` file.
+Validation will automatically be run after the conversion is complete. Any validation errors or warnings will be reported both on the command line and as part of the `INPUT_map.json` file.
 
 ## Format of the output file
 
@@ -41,9 +41,13 @@ Validation will automatically be run after the conversion is complete. Any valid
     "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml",
     "katsu_sha": < git sha of the katsu version used for the schema >,
     "donors": < An array of JSON objects, each one representing a DonorWithClinicalData in katsu >,
+    "validation_warnings": [
+        < any validation warnings, e.g. >
+        "DONOR_5: cause_of_death required if is_deceased = Yes"
+    ],
     "validation_errors": [
         < any validation errors, e.g. >
-        "DONOR_5: cause_of_death required if is_deceased = Yes"
+        "DONOR_5 > PD_5 > TR_5 > Radiation 1: Only one radiation is allowed per treatment"
     ],
     "statistics": {
         "required_but_missing": {
@@ -154,7 +158,7 @@ $ python validate_coverage.py [-h] [--input map.json] [--manifest MAPPING]
 
 --manifest: Path to a manifest file describing the mapping
 ```
-Issues caused by invalid jsonschema requirements will throw exceptions: these must be addressed before validation can be completed. Issues caused by failed conditions in the MoH model will be listed in the output.
+The output will report errors and warnings separately. Jsonschema validation failures and other data mismatches will be listed as errors, while fields that are conditionally required as part of the MoH model but are missing will be reported as warnings.
 
 
 <!-- # NOTE: the following sections have not been updated for current versions.

--- a/mohschema.py
+++ b/mohschema.py
@@ -204,7 +204,7 @@ class MoHSchema(BaseSchema):
                 case "date_alive_after_lost_to_followup":
                     if map_json["date_alive_after_lost_to_followup"] is not None:
                         if "lost_to_followup_after_clinical_event_identifier" not in map_json:
-                            self.warn("lost_to_followup_after_clinical_event_identifier needs to be submitted if date_alive_after_lost_to_followup is submitted")
+                            self.warn("lost_to_followup_after_clinical_event_identifier is required if date_alive_after_lost_to_followup is submitted")
                 case "cause_of_death":
                     if map_json["cause_of_death"] is not None:
                         if not map_json["is_deceased"]:
@@ -222,7 +222,7 @@ class MoHSchema(BaseSchema):
                 case "biomarkers":
                     for x in map_json["biomarkers"]:
                         if "test_date" not in x or x["test_date"] is None:
-                            self.warn("test_date is necessary for biomarkers not associated with nested events")
+                            self.warn("test_date is required for biomarkers not associated with nested events")
 
 
     def validate_primary_diagnoses(self, map_json):

--- a/mohschema.py
+++ b/mohschema.py
@@ -196,11 +196,11 @@ class MoHSchema(BaseSchema):
                 case "lost_to_followup_after_clinical_event_identifier":
                     if map_json["lost_to_followup_after_clinical_event_identifier"] is not None:
                         if map_json["is_deceased"]:
-                            self.warn("lost_to_followup_after_clinical_event_identifier cannot be present if is_deceased = Yes")
+                            self.fail("lost_to_followup_after_clinical_event_identifier cannot be present if is_deceased = Yes")
                 case "lost_to_followup_reason":
                     if map_json["lost_to_followup_reason"] is not None:
                         if "lost_to_followup_after_clinical_event_identifier" not in map_json:
-                            self.warn("lost_to_followup_reason should only be submitted if lost_to_followup_after_clinical_event_identifier is submitted")
+                            self.fail("lost_to_followup_reason should only be submitted if lost_to_followup_after_clinical_event_identifier is submitted")
                 case "date_alive_after_lost_to_followup":
                     if map_json["date_alive_after_lost_to_followup"] is not None:
                         if "lost_to_followup_after_clinical_event_identifier" not in map_json:
@@ -208,17 +208,17 @@ class MoHSchema(BaseSchema):
                 case "cause_of_death":
                     if map_json["cause_of_death"] is not None:
                         if not map_json["is_deceased"]:
-                            self.warn("cause_of_death should only be submitted if is_deceased = Yes")
+                            self.fail("cause_of_death should only be submitted if is_deceased = Yes")
                 case "date_of_death":
                     if map_json["date_of_death"] is not None:
                         if not map_json["is_deceased"]:
-                            self.warn("date_of_death should only be submitted if is_deceased = Yes")
+                            self.fail("date_of_death should only be submitted if is_deceased = Yes")
                         else:
                             if map_json["date_of_birth"] is not None:
                                 death = dateparser.parse(map_json["date_of_death"]).date()
                                 birth = dateparser.parse(map_json["date_of_birth"]).date()
                                 if birth > death:
-                                    self.warn("date_of_death cannot be earlier than date_of_birth")
+                                    self.fail("date_of_death cannot be earlier than date_of_birth")
                 case "biomarkers":
                     for x in map_json["biomarkers"]:
                         if "test_date" not in x or x["test_date"] is None:
@@ -361,7 +361,7 @@ class MoHSchema(BaseSchema):
     def validate_radiations(self, map_json):
         index = self.validation_schema["radiations"]["extra_args"]["index"]
         if index > 0:
-            self.warn("Only one radiation is allowed per treatment")
+            self.fail("Only one radiation is allowed per treatment")
 
         for prop in map_json:
             match prop:
@@ -375,7 +375,7 @@ class MoHSchema(BaseSchema):
         specimen_ids = self.validation_schema["primary_diagnoses"]["extra_args"]["specimen_ids"]
         index = self.validation_schema["surgeries"]["extra_args"]["index"]
         if index > 0:
-            self.warn("Only one surgery is allowed per treatment")
+            self.fail("Only one surgery is allowed per treatment")
 
         if "submitter_specimen_id" not in map_json:
             if "surgery_site" not in map_json or map_json["surgery_site"] is None:
@@ -384,7 +384,7 @@ class MoHSchema(BaseSchema):
                 self.warn("surgery_location required if submitter_specimen_id not submitted")
         else:
             if map_json["submitter_specimen_id"] not in specimen_ids:
-                self.warn(f"submitter_specimen_id {map_json['submitter_specimen_id']} does not correspond to one of the available specimen_ids {specimen_ids}")
+                self.fail(f"submitter_specimen_id {map_json['submitter_specimen_id']} does not correspond to one of the available specimen_ids {specimen_ids}")
 
 
     def validate_comorbidities(self, map_json):
@@ -392,13 +392,13 @@ class MoHSchema(BaseSchema):
             match prop:
                 case "laterality_of_prior_malignancy":
                     if "prior_malignancy" not in map_json or map_json["prior_malignancy"] != "Yes":
-                        self.warn("laterality_of_prior_malignancy should not be submitted unless prior_malignancy = Yes")
+                        self.fail("laterality_of_prior_malignancy should not be submitted unless prior_malignancy = Yes")
 
 
     def validate_exposures(self, map_json):
         is_smoker = False
         if "tobacco_smoking_status" not in map_json or map_json["tobacco_smoking_status"] is None:
-            self.fail("tobacco_smoking_status required for exposure")
+            self.warn("tobacco_smoking_status required for exposure")
         else:
             if map_json["tobacco_smoking_status"] in [
                 "Current reformed smoker for <= 15 years",
@@ -408,14 +408,14 @@ class MoHSchema(BaseSchema):
             ]:
                 is_smoker = True
 
-        for prop in map_json:
-            match prop:
-                case "tobacco_type":
-                    if not is_smoker:
-                        self.warn(f"tobacco_type cannot be submitted for tobacco_smoking_status = {map_json['tobacco_smoking_status']}")
-                case "pack_years_smoked":
-                    if not is_smoker:
-                        self.warn(f"pack_years_smoked cannot be submitted for tobacco_smoking_status = {map_json['tobacco_smoking_status']}")
+            for prop in map_json:
+                match prop:
+                    case "tobacco_type":
+                        if not is_smoker:
+                            self.fail(f"tobacco_type cannot be submitted for tobacco_smoking_status = {map_json['tobacco_smoking_status']}")
+                    case "pack_years_smoked":
+                        if not is_smoker:
+                            self.fail(f"pack_years_smoked cannot be submitted for tobacco_smoking_status = {map_json['tobacco_smoking_status']}")
 
 
     def validate_staging_system(self, map_json, staging_type):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyYAML>=5.4.1
 dateparser~=1.1.0
 openpyxl~=3.0.9
 requests~=2.29
-jsonschema~=3.2.0
+jsonschema~=4.19.1
 jsoncomparison~=1.1.0

--- a/schema.py
+++ b/schema.py
@@ -364,7 +364,7 @@ class BaseSchema:
                     if len(error.path) > 0:
                         location.append(error.path.popleft())
                 message = f"{' > '.join(location)}: {error.message}"
-                self.warn(message)
+                self.fail(message)
 
 
     def validate_schema(self, schema_name, map_json):

--- a/schema.py
+++ b/schema.py
@@ -331,7 +331,7 @@ class BaseSchema:
 
     def validate_schema(self, schema_name, map_json):
         id = f"{self.validation_schema[schema_name]['name']} {self.validation_schema[schema_name]['extra_args']['index']}"
-        if self.validation_schema[schema_name]["id"] is not None:
+        if self.validation_schema[schema_name]["id"] is not None and self.validation_schema[schema_name]["id"] in map_json:
             id = map_json[self.validation_schema[schema_name]["id"]]
             if schema_name not in self.identifiers:
                 self.identifiers[schema_name] = Counter()

--- a/schema.py
+++ b/schema.py
@@ -50,6 +50,7 @@ class BaseSchema:
 
     def __init__(self, url, simple=False):
         self.validation_warnings = []
+        self.validation_errors = []
         self.statistics = {}
         self.identifiers = {}
         self.stack_location = []
@@ -124,7 +125,7 @@ class BaseSchema:
         else:
             prefix += ": "
         message = prefix + message
-        raise ValidationError(message)
+        self.validation_errors.append(f"{message}")
 
 
     def expand_ref(self, ref):

--- a/schema.py
+++ b/schema.py
@@ -49,7 +49,7 @@ class BaseSchema:
 
 
     def __init__(self, url, simple=False):
-        self.validation_failures = []
+        self.validation_warnings = []
         self.statistics = {}
         self.identifiers = {}
         self.stack_location = []
@@ -114,7 +114,7 @@ class BaseSchema:
         else:
             prefix += ": "
         message = prefix + message
-        self.validation_failures.append(f"{message}")
+        self.validation_warnings.append(f"{message}")
 
 
     def fail(self, message):

--- a/schema.py
+++ b/schema.py
@@ -322,7 +322,7 @@ class BaseSchema:
             if most_common[0][1] > 1:
                 for x in most_common:
                     if x[1] > 1:
-                        self.warn(f"Duplicated IDs: in schema {schema}, {x[0]} occurs {x[1]} times")
+                        self.fail(f"Duplicated IDs: in schema {schema}, {x[0]} occurs {x[1]} times")
         self.statistics["schemas_not_used"] = list(set(self.validation_schema.keys()) - set(self.statistics["schemas_used"]))
         self.statistics["summary_cases"] = {
             "complete_cases": len(map_json["donors"]) - len(self.statistics["cases_missing_data"]),

--- a/test_data_ingest.py
+++ b/test_data_ingest.py
@@ -101,8 +101,8 @@ def test_donor_2(packets):
 
 def test_validation(packets, schema):
     schema.validate_ingest_map({"donors": packets})
-    print(schema.validation_failures)
-    assert len(schema.validation_failures) == 9
+    print(schema.validation_warnings)
+    assert len(schema.validation_warnings) == 9
     # should be the following 9 failures:
     # DONOR_5: cause_of_death required if is_deceased = Yes
     # DONOR_5: date_of_death required if is_deceased = Yes

--- a/test_data_ingest.py
+++ b/test_data_ingest.py
@@ -102,15 +102,19 @@ def test_donor_2(packets):
 def test_validation(packets, schema):
     schema.validate_ingest_map({"donors": packets})
     print(schema.validation_warnings)
-    assert len(schema.validation_warnings) == 9
-    # should be the following 9 failures:
+    assert len(schema.validation_warnings) == 6
+    # should be the following 6 warnings:
     # DONOR_5: cause_of_death required if is_deceased = Yes
     # DONOR_5: date_of_death required if is_deceased = Yes
     # DONOR_5 > PD_5: clinical_stage_group is required for clinical_tumour_staging_system Revised International staging system (RISS)
     # DONOR_5 > PD_5 > SPECIMEN_6: Tumour specimens require a reference_pathology_confirmed_diagnosis
-    # DONOR_5 > PD_5 > TR_5 > Radiation 1: Only one radiation is allowed per treatment
     # DONOR_5 > PD_5 > TR_5 > Radiation 1: reference_radiation_treatment_id required if radiation_boost = Yes
     # DONOR_5 > PD_5 > TR_10: treatment type Immunotherapy should have one or more immunotherapies submitted
+
+    print(schema.validation_errors)
+    assert len(schema.validation_errors) == 3
+    # should be the following 3 errors:
+    # DONOR_5 > PD_5 > TR_5 > Radiation 1: Only one radiation is allowed per treatment
     # DONOR_6 > PD_6 > TR_9 > Surgery 0: submitter_specimen_id SPECIMEN_43 does not correspond to one of the available specimen_ids ['SPECIMEN_3']
     # Duplicated IDs: in schema followups, FOLLOW_UP_4 occurs 2 times
 

--- a/validate_coverage.py
+++ b/validate_coverage.py
@@ -219,7 +219,7 @@ def validate_coverage(map_json, input_path=None, verbose=False):
     print("Validating the mapped schema...")
     schema.validate_ingest_map(map_json)
     # print(json.dumps(schema.validation_results, indent=4))
-    return schema.validation_failures
+    return schema.validation_warnings
 
 def main(args):
     if args.json is not None and os.path.isfile(args.json):

--- a/validate_coverage.py
+++ b/validate_coverage.py
@@ -219,7 +219,10 @@ def validate_coverage(map_json, input_path=None, verbose=False):
     print("Validating the mapped schema...")
     schema.validate_ingest_map(map_json)
     # print(json.dumps(schema.validation_results, indent=4))
-    return schema.validation_warnings
+    return {
+        "errors": schema.validation_errors,
+        "warnings": schema.validation_warnings
+    }
 
 def main(args):
     if args.json is not None and os.path.isfile(args.json):

--- a/validate_coverage.py
+++ b/validate_coverage.py
@@ -236,11 +236,15 @@ def main(args):
     input_path = args.input
     verbose = True if args.verbose else False
     result = validate_coverage(map_json, input_path, verbose)
-    if len(result) == 0:
+    if len(result["warnings"]) > 0:
+        print("Mapping has missing data:")
+        for line in result["warnings"]:
+            print(line)
+    if len(result["errors"]) == 0:
         print("Mapping is valid!")
     else:
         print("\n\nValidation failures:")
-        for line in result:
+        for line in result["errors"]:
             print(line)
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are now two separate lists, `validation_errors` and `validation_warnings`. Neither of them explicitly cause exceptions to be thrown. Ingest will have to look at the two lists and throw an error when validation errors are present, but report warnings as well.

The test_validation test now distinguishes between the two.

Note: this branch includes changes from #36.