### PR TITLE
fix mapping functions for surgeries in mapping template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
           bytes=$(head -5 curr_diff.txt | wc -c)
           dd if=curr_diff.txt bs="$bytes" skip=1 conv=notrunc of=curr_diff.txt
           diff curr_diff.txt test_data/moh_diffs.txt
-      - name: Explain moh_template.csv failure
-        if: ${{ failure() }}
-        run: echo See https://github.com/CanDIG/clinical_ETL_code#mapping-template for information
+          if [[ $? == 1 ]]; then echo MoH template checking needs to be updated! See https://github.com/CanDIG/clinical_ETL_code#mapping-template for information.
+          exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,6 @@ jobs:
           bytes=$(head -5 curr_diff.txt | wc -c)
           dd if=curr_diff.txt bs="$bytes" skip=1 conv=notrunc of=curr_diff.txt
           diff curr_diff.txt test_data/moh_diffs.txt
+      - name: Explain moh_template.csv failure
+        if: ${{ failure() }}
+        run: echo See https://github.com/CanDIG/clinical_ETL_code#mapping-template for information

--- a/README.md
+++ b/README.md
@@ -114,8 +114,15 @@ You'll need to create a mapping template that defines which mapping functions (i
 If you're generating a mapping for the current MoH model, you can use the pre-generated `moh_template.csv` file. This file is modified from the auto-generated template to update a few fields that require specific handling.
 
 <details>
-<summary>Updating the moh_template.csv file</summary>
-If the MoH model changes in katsu, the GitHub Action check "Compare moh_template.csv" will fail.
+<summary>"Compare moh_template.csv" fails</summary>
+
+### You changed the `moh_template.csv` file:
+
+To fix this, you'll need to update the diffs file. Run `bash update_moh_template.sh` and commit the changes that are generated for `test_data/moh_diffs.txt`.
+
+### You did not change the `moh_template.csv` file:
+
+There have probably been MoH model changes in katsu.
 
 Run the `update_moh_template.sh` script to see what's changed in `test_data/moh_diffs.txt`. Update `moh_template.csv` to reconcile any differences, then re-run `update_moh_template.sh`. Commit any changes in both `moh_template.csv` and `test_data/moh_diffs.txt`.
 </details>

--- a/moh_template.csv
+++ b/moh_template.csv
@@ -104,9 +104,9 @@ DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.surgery_sit
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.surgery_location, {single_val(SURGERIES_SHEET.surgery_location)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_focality, {single_val(SURGERIES_SHEET.tumour_focality)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.residual_tumour_classification, {single_val(SURGERIES_SHEET.residual_tumour_classification)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_involved)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_not_involved)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_not_assessed)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.lymphovascular_invasion, {single_val(SURGERIES_SHEET.lymphovascular_invasion)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.perineural_invasion, {single_val(SURGERIES_SHEET.perineural_invasion)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.submitter_specimen_id, {single_val(SURGERIES_SHEET.submitter_specimen_id)}

--- a/moh_template.csv
+++ b/moh_template.csv
@@ -181,3 +181,4 @@ DONOR.INDEX.followups.INDEX.recurrence_t_category, {single_val(FOLLOWUPS_SHEET.r
 DONOR.INDEX.followups.INDEX.recurrence_n_category, {single_val(FOLLOWUPS_SHEET.recurrence_n_category)}
 DONOR.INDEX.followups.INDEX.recurrence_m_category, {single_val(FOLLOWUPS_SHEET.recurrence_m_category)}
 DONOR.INDEX.followups.INDEX.recurrence_stage_group, {single_val(FOLLOWUPS_SHEET.recurrence_stage_group)}
+test

--- a/moh_template.csv
+++ b/moh_template.csv
@@ -104,9 +104,9 @@ DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.surgery_sit
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.surgery_location, {single_val(SURGERIES_SHEET.surgery_location)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_focality, {single_val(SURGERIES_SHEET.tumour_focality)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.residual_tumour_classification, {single_val(SURGERIES_SHEET.residual_tumour_classification)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.lymphovascular_invasion, {single_val(SURGERIES_SHEET.lymphovascular_invasion)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.perineural_invasion, {single_val(SURGERIES_SHEET.perineural_invasion)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.submitter_specimen_id, {single_val(SURGERIES_SHEET.submitter_specimen_id)}

--- a/moh_template.csv
+++ b/moh_template.csv
@@ -181,4 +181,3 @@ DONOR.INDEX.followups.INDEX.recurrence_t_category, {single_val(FOLLOWUPS_SHEET.r
 DONOR.INDEX.followups.INDEX.recurrence_n_category, {single_val(FOLLOWUPS_SHEET.recurrence_n_category)}
 DONOR.INDEX.followups.INDEX.recurrence_m_category, {single_val(FOLLOWUPS_SHEET.recurrence_m_category)}
 DONOR.INDEX.followups.INDEX.recurrence_stage_group, {single_val(FOLLOWUPS_SHEET.recurrence_stage_group)}
-test

--- a/test_data/moh_diffs.txt
+++ b/test_data/moh_diffs.txt
@@ -96,11 +96,5 @@
 ---
 > DONOR.INDEX.followups.INDEX.method_of_progression_status, {pipe_delim(FOLLOWUPS_SHEET.method_of_progression_status)}
 > DONOR.INDEX.followups.INDEX.anatomic_site_progression_or_recurrence, {pipe_delim(FOLLOWUPS_SHEET.anatomic_site_progression_or_recurrence)}
-182a184
-> test
-\ No newline at end of file
-FOLLOWUPS_SHEET.method_of_progression_status)}
+.method_of_progression_status, {pipe_delim(FOLLOWUPS_SHEET.method_of_progression_status)}
 > DONOR.INDEX.followups.INDEX.anatomic_site_progression_or_recurrence, {pipe_delim(FOLLOWUPS_SHEET.anatomic_site_progression_or_recurrence)}
-182a184
-> test
-\ No newline at end of file

--- a/test_data/moh_diffs.txt
+++ b/test_data/moh_diffs.txt
@@ -40,6 +40,14 @@
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_fractions, {integer(RADIATIONS_SHEET.radiation_therapy_fractions)}
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_therapy_dosage, {integer(RADIATIONS_SHEET.radiation_therapy_dosage)}
 > DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.radiations.INDEX.radiation_boost, {boolean(RADIATIONS_SHEET.radiation_boost)}
+106,108c107,109
+< DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_involved)}
+< DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_not_involved)}
+< DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_not_assessed)}
+---
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
 112,114c113,115
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_length, {single_val(SURGERIES_SHEET.tumour_length)}
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_width, {single_val(SURGERIES_SHEET.tumour_width)}

--- a/test_data/moh_diffs.txt
+++ b/test_data/moh_diffs.txt
@@ -45,9 +45,9 @@
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_not_involved)}
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {indexed_on(SURGERIES_SHEET.margin_types_not_assessed)}
 ---
-> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
-> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
-> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
+> DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
 112,114c113,115
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_length, {single_val(SURGERIES_SHEET.tumour_length)}
 < DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_width, {single_val(SURGERIES_SHEET.tumour_width)}
@@ -96,5 +96,11 @@
 ---
 > DONOR.INDEX.followups.INDEX.method_of_progression_status, {pipe_delim(FOLLOWUPS_SHEET.method_of_progression_status)}
 > DONOR.INDEX.followups.INDEX.anatomic_site_progression_or_recurrence, {pipe_delim(FOLLOWUPS_SHEET.anatomic_site_progression_or_recurrence)}
-.method_of_progression_status, {pipe_delim(FOLLOWUPS_SHEET.method_of_progression_status)}
+182a184
+> test
+\ No newline at end of file
+FOLLOWUPS_SHEET.method_of_progression_status)}
 > DONOR.INDEX.followups.INDEX.anatomic_site_progression_or_recurrence, {pipe_delim(FOLLOWUPS_SHEET.anatomic_site_progression_or_recurrence)}
+182a184
+> test
+\ No newline at end of file


### PR DESCRIPTION
We found that the mapping functions used for 

- `DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX`
- `DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX`
- `DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX`

should be `pipe_delim()` rather than `indexed_on()` 

this PR fixes the issue