### PR TITLE
Generalize schema class used for conversion/validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ For each dataset (cohort) that you want to convert, create a directory outside o
 #### Manifest file
 The `manifest.yml` file contains settings for the cohort mapping. There is a sample file in [`sample_inputs/manifest.yml`](sample_inputs/manifest.yml) with documentation and example inputs. The fields are:
 
-| field       | description                                                                                                                                                           |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| description | A brief description of what mapping task this manifest is being used for                                                                                              |
-| mapping     | the mapping template csv file that lists the mappings for each field based on `moh_template.csv`, assumed to be in the same directory as the `manifest.yml` file      |
-| identifier  | the unique identifier for the donor or root node                                                                                                                      |
-| schema      | a URL to the openapi schema file                                                                                                                                      |
-| functions   | A list of one or more filenames containing additional mapping functions, can be omitted if not needed. Assumed to be in the same directory as the `manifest.yml` file |
+| field         | description                                                                                                                                                                                               |
+|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| description   | A brief description of what mapping task this manifest is being used for                                                                                                                                  |
+| mapping       | the mapping template csv file that lists the mappings for each field based on `moh_template.csv`, assumed to be in the same directory as the `manifest.yml` file                                          |
+| identifier    | the unique identifier for the donor or root node                                                                                                                                                          |
+| schema        | a URL to the openapi schema file                                                                                                                                                                          |
+| schema_class  | The name of the class in the schema used as the model for creating the map.json. Currently supported: `MoHSchema` - for clinical MoH data and `GenomicSchema` for creating a genomic ingest linking file. |
+| functions     | A list of one or more filenames containing additional mapping functions, can be omitted if not needed. Assumed to be in the same directory as the `manifest.yml` file                                     |
 
 #### Mapping template
 

--- a/sample_inputs/manifest.yml
+++ b/sample_inputs/manifest.yml
@@ -5,7 +5,9 @@ mapping: moh_template.csv
 identifier: submitter_donor_id
 # a link to the openapi schema
 schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml
-# one or more files (dataset_functions.py) that implement the mappings 
+# class of schema for validation:
+schema_class: MoHSchema
+# one or more files (dataset_functions.py) that implement the mappings
 # described in mapping file
 functions:
   - new_cohort

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -667,9 +667,11 @@ def csv_convert(input_path, manifest_file, verbose=False):
     with open(f"{mappings.OUTPUT_FILE}_indexed.json", 'w') as f:
         json.dump(mappings.INDEXED_DATA, f, indent=4)
 
+    result_key = list(schema.validation_schema.keys()).pop(0)
+
     result = {
         "openapi_url": schema.openapi_url,
-        "donors": packets
+        result_key: packets
     }
     if schema.katsu_sha is not None:
         result["katsu_sha"] = schema.katsu_sha

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -557,6 +557,7 @@ def load_manifest(manifest_file):
     identifier = None
     schema = "mcode"
     mapping_path = None
+    result = {}
     try:
         with open(manifest_file, 'r') as f:
             manifest = yaml.safe_load(f)
@@ -568,15 +569,16 @@ def load_manifest(manifest_file):
         sys.exit(f"Manifest file not found at provided path: {manifest_file}")
 
     if "identifier" in manifest:
-        identifier = manifest["identifier"]
+        result["identifier"] = manifest["identifier"]
     if "schema" in manifest:
-        schema = manifest["schema"]
+        result["schema"] = manifest["schema"]
     if "mapping" in manifest:
         mapping_file = manifest["mapping"]
         manifest_dir = os.path.dirname(os.path.abspath(manifest_file))
         mapping_path = os.path.join(manifest_dir, mapping_file)
         if os.path.isabs(mapping_file):
             mapping_path = manifest_file
+        result["mapping"] = mapping_path
 
     if "functions" in manifest:
         for mod in manifest["functions"]:
@@ -595,11 +597,7 @@ def load_manifest(manifest_file):
                 sys.exit(e)
     # mappings is a standard module: add it
     mappings.MODULES["mappings"] = importlib.import_module("clinical_etl.mappings")
-    return {
-        "identifier": identifier,
-        "schema": schema,
-        "mapping": mapping_path
-    }
+    return result
 
 
 def csv_convert(input_path, manifest_file, verbose=False):

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -603,6 +603,7 @@ def load_manifest(manifest_file):
 def csv_convert(input_path, manifest_file, verbose=False):
     mappings.VERBOSE = verbose
     # read manifest data
+    print("Starting conversion")
     manifest = load_manifest(manifest_file)
     mappings.IDENTIFIER_FIELD = manifest["identifier"]
     if mappings.IDENTIFIER_FIELD is None:
@@ -611,6 +612,7 @@ def csv_convert(input_path, manifest_file, verbose=False):
 
     # read the schema (from the url specified in the manifest) and generate
     # a scaffold
+    print("Loading schema")
     schema = MoHSchema(manifest["schema"])
     if schema.json_schema is None:
         sys.exit(f"Could not read an openapi schema at {manifest['schema']};\n"

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -657,7 +657,8 @@ def csv_convert(input_path, manifest_file, verbose=False):
         mappings._push_to_stack(None, None, 0)
         packet = map_data_to_scaffold(deepcopy(mapping_scaffold), None, 0)
         if packet is not None:
-            packets.extend(packet["DONOR"])
+            main_key = list(packet.keys())[0]
+            packets.extend(packet[main_key])
         if mappings._pop_from_stack() is None:
             raise Exception(f"Stack popped too far!\n{mappings.IDENTIFIER_FIELD}: {mappings.IDENTIFIER}")
         if mappings._pop_from_stack() is not None:

--- a/src/clinical_etl/genomicschema.py
+++ b/src/clinical_etl/genomicschema.py
@@ -33,5 +33,9 @@ class GenomicSchema(BaseSchema):
     }
 
 
+    def validate_genomic_ids(self, map_json):
+        return
+
+
     def validate_samples(self, map_json):
         return

--- a/src/clinical_etl/schema.py
+++ b/src/clinical_etl/schema.py
@@ -51,7 +51,7 @@ class BaseSchema:
 
     # schema for validation beyond jsonschema checks. Each schema that is described in the model gets an entry.
     validation_schema = {
-        "example": {             # There should be a method `validate_example` implemented to validate conditionals
+        "examples": {             # There should be a method `validate_examples` implemented to validate conditionals
             "id": "example_id",  # The id used to disambiguate instances of the schema. If None, an array index is used
             "name": "Example",   # The proper name for the schema
             "required_fields": [ # Any fields specified as required in the model (but not absolutely necessary for jsonschema)
@@ -59,10 +59,10 @@ class BaseSchema:
                 "attribute_1"
             ],
             "nested_schemas": [  # Any schema instances that may be nested within instances of this schema.
-                "example_2"      # Nested instances will be validated as part of the validation of the parent.
+                "more_examples"      # Nested instances will be validated as part of the validation of the parent.
             ]
         },
-        "example_2": {
+        "more_examples": {
             "id": None,
             "name": "Example 2",
             "required_fields": [],

--- a/src/clinical_etl/validate_coverage.py
+++ b/src/clinical_etl/validate_coverage.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import sys
 import mappings
-from mohschema import MoHSchema
+import importlib.util
 # from jsoncomparison import Compare
 # from copy import deepcopy
 # import yaml
@@ -207,7 +207,12 @@ def validate_coverage(map_json, verbose=False):
     # read the schema and generate a scaffold
     if "openapi_url" not in map_json:
         return {"message": "No openapi_url schema available"}
-    schema = MoHSchema(map_json["openapi_url"])
+    schema_class = "MoHSchema"
+    if "schema_class" in map_json:
+        schema_class = map_json["schema_class"]
+    schema_mod = importlib.import_module(f"clinical_etl.{schema_class.lower()}")
+    schema = getattr(schema_mod, schema_class)(map_json["openapi_url"])
+
     if schema.json_schema is None:
         sys.exit(f"Did not find an openapi schema at {map_json['openapi_url']}; please check the 'openapi_url' in the map json file.")
 


### PR DESCRIPTION
If your manifest file specifies a schema_class key, clinical_etl will use that class to generate the mapping json and to validate.

Pytest still works; the main difference is that now we can use the GenomicSchema class for conversions as well.