### PR TITLE
Module path changes to allow running standalone (not as an included m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You can validate the generated json mapping file against the MoH data model. The
 
 ```
 $ python src/clinical_etl/validate_coverage.py -h
-validate_coverage.py [-h] [--input map.json] [--manifest MAPPING]
+usage: validate_coverage.py [-h] --json JSON [--verbose]
 
 options:
   -h, --help      show this help message and exit

--- a/mapping_functions.md
+++ b/mapping_functions.md
@@ -66,15 +66,23 @@ A detailed index of all standard functions can be viewed below in the [Standard 
 
 ## Writing your own custom functions
 
-If the data cannot be transformed with one of the standard functions, you can define your own. In your data directory (the one that contains `manifest.yml`) create a python file (let's assume you called it `new_cohort.py`) and add the name of that file as the `mapping` entry in the manifest.
+If the data cannot be transformed with one of the standard functions, you can define your own.
 
-Following the format in the generic `mappings.py`, write your own functions in your python file for how to translate the data. To specify a custom mapping function in the template:
+In your data directory (the one that contains `manifest.yml`) create a python file (let's assume you called it `new_cohort.py`) and add the name of that file as a .yml list after `functions` in the manifest.  For example:
+```
+functions:
+  - new_cohort
+```
 
-`DONOR.INDEX.primary_diagnoses.INDEX.basis_of_diagnosis,{new_cohort.custom_function(DATA_SHEET.field_name)}`
+Following the format in the generic `mappings.py`, write your own functions in your python file to translate the data.
+
+To use a custom mapping function in the template, you must specify the file and function using dot-separated notation:
+
+DONOR.INDEX.primary_diagnoses.INDEX.basis_of_diagnosis,{**new_cohort.custom_function**(DATA_SHEET.field_name)}
 
 Examples:
 
-To map input values to output values (in case your data capture used different values than the model):
+Map input values to output values (in case your data capture used different values than the model):
 
 ```
 def sex(data_value):

--- a/sample_inputs/new_cohort.py
+++ b/sample_inputs/new_cohort.py
@@ -1,5 +1,12 @@
-## Additional mappings customised to my special cohort
+import os
+import sys
+# Include src/ directory in the module search path.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(os.sep.join([parent_dir, "src"]))
+import clinical_etl.mappings
 
+## Additional mappings customised to my special cohort
 def sex(data_value):
     # make sure we only have one value
     mapping_val = mappings.single_val(data_value)

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import sys
+import os
 from copy import deepcopy
 import importlib.util
 import json
-from clinical_etl import mappings
-import os
 import pandas
 import csv
 import re
-import sys
 import yaml
 import argparse
+# Include clinical_etl parent directory in the module search path.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+from clinical_etl import mappings
 
 
 def verbose_print(message):

--- a/src/clinical_etl/validate_coverage.py
+++ b/src/clinical_etl/validate_coverage.py
@@ -3,6 +3,11 @@ import json
 import sys
 import mappings
 import importlib.util
+import os
+# Include clinical_etl parent directory in the module search path for a later import.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
 # from jsoncomparison import Compare
 # from copy import deepcopy
 # import yaml

--- a/tests/test_data_ingest.py
+++ b/tests/test_data_ingest.py
@@ -1,9 +1,14 @@
 import pytest
 import yaml
+import os
+import sys
+import json
+# Include src/clinical_etl directory in the module search path.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(os.sep.join([parent_dir, "src"]))
 from clinical_etl import CSVConvert
 from clinical_etl import mappings
-import json
-import os
 from clinical_etl.mohschema import MoHSchema
 
 # read sheet from given data pathway

--- a/tests/testmap.py
+++ b/tests/testmap.py
@@ -1,3 +1,9 @@
+import os
+import sys
+# Include src/ directory in the module search path.
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(os.sep.join([parent_dir, "src"]))
 import clinical_etl.mappings
 
 def indexed_on_if_absent(data_values):


### PR DESCRIPTION
The changes to include clinical_ETL_code as an imported module (rather than a git submodule) broke its ability to tun as a standalone program.
Changes are here made to the sys.path to allow import statements whether running as an imported module or as a standalone.
Included pytests now run successfully.