### PR TITLE
DIG-1473: Accept date intervals (rather than absolute dates).

### DIFF
--- a/mapping_functions.md
+++ b/mapping_functions.md
@@ -242,13 +242,13 @@ Functions
 
 
 `int_to_date_interval_json(data_values)`
-:   Converts an integer date interval into JSON format, specifying either a month or day interval.
+:   Converts an integer date interval into JSON format.
 
     Args:
         data_values: a values dict with an integer.
 
     Returns:
-        A dictionary with calculated month_interval or day_interval depending on the specified date_resolution in the donor file.
+        A dictionary with a calculated month_interval and optionally a day_interval depending on the specified date_resolution in the donor file.
 
 
 `integer(data_values)`

--- a/mapping_functions.md
+++ b/mapping_functions.md
@@ -58,15 +58,15 @@ If your schema requires more complex mapping calculations, you can define an ind
 
 In addition to mapping column names, you can also transform the values inside the cells to make them align with the schema. We've already seen the simplest case - the `single_val` function takes a single value for the named field and returns it (and should only be used when you expect one single value).
 
-The standard functions are defined in `mappings.py`. They include functions for handling single values, list values, dates, and booleans. 
+The standard functions are defined in `mappings.py`. They include functions for handling single values, list values, dates, and booleans.
 
-Many functions take one or more `data_values` arguments as input. These are a dictionary representing how the CSVConvert script parses each cell of the input data. It is a dictionary of the format `{<field>:{<OBJECT_SHEET>: <value>}}`, e.g. `{'date_of_birth': {'Donor': '6 Jan 1954'}}`. 
+Many functions take one or more `data_values` arguments as input. These are a dictionary representing how the CSVConvert script parses each cell of the input data. It is a dictionary of the format `{<field>:{<OBJECT_SHEET>: <value>}}`, e.g. `{'date_of_birth': {'Donor': '6 Jan 1954'}}`.
 
 A detailed index of all standard functions can be viewed below in the [Standard functions index](#Standard-functions-index).
 
 ## Writing your own custom functions
 
-If the data cannot be transformed with one of the standard functions, you can define your own.
+If the data cannot be transformed with one of the standard functions, you can define your own. In your data directory (the one that contains `manifest.yml`) create a python file (let's assume you called it `new_cohort.py`) and add the name of that file as the `functions` entry in the manifest (without the .py extension).
 
 In your data directory (the one that contains `manifest.yml`) create a python file (let's assume you called it `new_cohort.py`) and add the name of that file as a .yml list after `functions` in the manifest.  For example:
 ```
@@ -140,13 +140,13 @@ Module mappings
 Functions
 ---------
 
-    
+
 `boolean(data_values)`
 :   Convert value to boolean.
-    
+
     Args:
         data_values: A string to be converted to a boolean
-    
+
     Returns:
         A boolean based on the input,
         `False` if value is in ["No", "no", "N", "n", "False", "false", "F", "f"]
@@ -154,96 +154,106 @@ Functions
         None if value is in [`None`, "nan", "NaN", "NAN"]
         None otherwise
 
-    
+
 `concat_vals(data_values)`
 :   Concatenate several data values
-    
+
     Args:
         data_values: a values dict with a list of values
-    
+
     Returns:
         A concatenated string
 
-    
+
 `date(data_values)`
 :   Format a list of dates to ISO standard YYYY-MM
-    
+
     Parses a list of strings representing dates into a list of strings with dates in ISO format YYYY-MM.
-    
+
     Args:
         data_values: a value dict with a list of date-like strings
-    
+
     Returns:
         a list of dates in YYYY-MM format or None if blank/empty/unparseable
 
-    
+
 `date_interval(data_values)`
 :   Calculates a date interval from a given date relative to the reference date specified in the manifest.
-    
+
     Args:
         data_values: a values dict with a date
-    
+
     Returns:
         A dictionary with calculated month_interval and optionally a day_interval depending on the specified
         date_resolution.
 
-    
+
 `earliest_date(data_values)`
 :   Calculates the earliest date from a set of dates
-    
+
     Args:
         data_values: A values dict of dates of diagnosis and date_resolution
-    
+
     Returns:
         A dictionary containing the earliest date (`offset`) as a date object and the provided `date_resolution`
 
-    
+
 `flat_list_val(data_values)`
 :   Take a list mapping and break up any stringified lists into multiple values in the list.
-    
+
     Attempts to use ast.literal_eval() to parse the list, uses split(',') if this fails.
-    
+
     Args:
         data_values: a values dict with a stringified list, e.g. "['a','b','c']"
     Returns:
         A parsed list of items in the list, e.g. ['a', 'b', 'c']
 
-    
+
 `float(data_values)`
 :   Convert a value to a float.
-    
+
     Args:
         data_values: A values dict
-    
+
     Returns:
         A values dict with a string or integer converted to a float or None if null value
-    
+
     Raises:
         ValueError by float() if it cannot convert to float.
 
-    
+
 `has_value(data_values)`
 :   Returns a boolean based on whether the key in the mapping has a value.
 
-    
+
 `index_val(data_values)`
 :   Take a mapping with possibly multiple values from multiple sheets and return an array.
 
-    
+
 `indexed_on(data_values)`
 :   Default indexing value for arrays.
-    
+
     Args:
         data_values: a values dict of identifiers to be indexed
-    
+
     Returns:
         a dict of the format:
         {"field": <identifier_field>,"sheet_name": <sheet_name>,"values": [<identifiers>]}
 
-    
+
+`int_to_date_interval_json(data_values)`
+:   Converts an integer date interval into JSON format, specifying either a month or day interval.
+
+    Args:
+        data_values: a values dict with an integer.
+
+    Returns:
+        A dictionary with calculated month_interval or day_interval depending on the specified date_resolution in the donor file.
+
+
 `integer(data_values)`
 :   Convert a value to an integer.
-    
+
     Args:
         data_values: a values dict with value to be converted to an int
     Returns:
@@ -251,81 +261,81 @@ Functions
     Raises:
         ValueError if int() cannot convert the input
 
-    
+
 `list_val(data_values)`
 :   Takes a mapping with possibly multiple values from multiple sheets and returns an array of values.
-    
+
     Args:
         data_values: a values dict with a list of values
     Returns:
         The list of values
 
-    
+
 `moh_indexed_on_donor_if_others_absent(data_values)`
 :   Maps an object to a donor if not otherwise linked.
-    
+
     Specifically for the FollowUp object which can be linked to multiple objects.
-    
+
     Args:
         **data_values: any number of values dicts with lists of identifiers, NOTE: values dict with donor identifiers
         must be specified first.
-    
+
     Returns:
         a dict of the format:
-    
+
             {'field': <field>, 'sheet': <sheet>, 'values': [<identifier or None>, <identifier or None>...]}
-    
+
         Where the 'values' list contains a donor identifier if it should be linked to that donor or None if already
         linked to another object.
 
-    
+
 `ontology_placeholder(data_values)`
 :   Placeholder function to make a fake ontology entry.
-    
+
     Should only be used for testing.
-    
+
     Args:
         data_values: a values dict with a string value representing an ontology label
-    
+
     Returns:
         a dict of the format:
         {"id": "placeholder","label": data_values}
 
-    
+
 `pipe_delim(data_values)`
 :   Takes a string and splits it into an array based on a pipe delimiter.
-    
+
     Args:
          data_values: values dict with single pipe-delimited string, e.g. "a|b|c"
-    
+
     Returns:
         a list of strings split by pipe, e.g. ["a","b","c"]
 
-    
+
 `placeholder(data_values)`
 :   Return a dict with a placeholder key.
 
-    
+
 `single_date(data_values)`
 :   Parses a single date to YYYY-MM format.
-    
+
     Args:
         data_values: a value dict with a date
-    
+
     Returns:
         a string of the format YYYY-MM, or None if blank/unparseable
 
-    
+
 `single_val(data_values)`
 :   Parse a values dict and return the input as a single value.
-    
+
     Args:
         data_values: a dict with values to be squashed
-    
+
     Returns:
         A single value with any null values removed
         None if list is empty or contains only 'nan', 'NaN', 'NAN'
-    
+
     Raises:
         MappingError if multiple values found
 

--- a/sample_inputs/moh_template.csv
+++ b/sample_inputs/moh_template.csv
@@ -105,9 +105,9 @@ DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.surgery_sit
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.surgery_location, {single_val(SURGERIES_SHEET.surgery_location)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.tumour_focality, {single_val(SURGERIES_SHEET.tumour_focality)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.residual_tumour_classification, {single_val(SURGERIES_SHEET.residual_tumour_classification)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
-DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed.INDEX, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_involved, {pipe_delim(SURGERIES_SHEET.margin_types_involved)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_involved, {pipe_delim(SURGERIES_SHEET.margin_types_not_involved)}
+DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.margin_types_not_assessed, {pipe_delim(SURGERIES_SHEET.margin_types_not_assessed)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.lymphovascular_invasion, {single_val(SURGERIES_SHEET.lymphovascular_invasion)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.perineural_invasion, {single_val(SURGERIES_SHEET.perineural_invasion)}
 DONOR.INDEX.primary_diagnoses.INDEX.treatments.INDEX.surgeries.INDEX.submitter_specimen_id, {single_val(SURGERIES_SHEET.submitter_specimen_id)}

--- a/src/clinical_etl/mappings.py
+++ b/src/clinical_etl/mappings.py
@@ -126,6 +126,8 @@ def int_to_date_interval_json(data_values):
     """
 
     # Dates are by nature messy.  This function does not account for leap years and February's 28 days, but is close enough.
+    if integer(data_values) is None:
+        return
     # Either month or day date resolutions are permitted.
     resolution = INDEXED_DATA["data"]["CALCULATED"][IDENTIFIER]["date_resolution"][0]
     try:

--- a/src/clinical_etl/mappings.py
+++ b/src/clinical_etl/mappings.py
@@ -131,7 +131,7 @@ def int_to_date_interval_json(data_values):
     except:
         raise MappingError("No date_resolution found to specify date interval resolution: is there a date_resolution specified in the donor file?")
     # Format as JSON, indicating interval resolution.
-    return {resolution + "_interval": single_val(data_values)}
+    return {resolution + "_interval": integer(data_values)}
 
 # Single date
 def single_date(data_values):

--- a/src/clinical_etl/mappings.py
+++ b/src/clinical_etl/mappings.py
@@ -58,8 +58,13 @@ def earliest_date(data_values):
     date_resolution = list(data_values[fields[0]].values())[0]
     dates = list(data_values[fields[1]].values())[0]
     earliest = DEFAULT_DATE_PARSER.get_date_data(str(datetime.date.today()))
-    for date_string in dates:
-        d = DEFAULT_DATE_PARSER.get_date_data(date_string)
+    # Ensure dates is a list, not a string, to allow non-indexed, single value entries.
+    if type(dates) is not list:
+        dates_list = [dates]
+    else:
+        dates_list = dates
+    for date in dates_list:
+        d = DEFAULT_DATE_PARSER.get_date_data(date)
         if d['date_obj'] < earliest['date_obj']:
             earliest = d
     return {
@@ -108,6 +113,25 @@ def date_interval(data_values):
         result["day_interval"] = day_interval
     return result
 
+def int_to_date_interval_json(data_values):
+    """Converts an integer date interval into JSON format, specifying either a month or day interval.
+
+    Args:
+        data_values: a values dict with an integer.
+
+    Returns:
+        A dictionary with calculated month_interval or day_interval depending on the specified date_resolution in the donor file.
+    """
+
+    # Lookup either month or day date resolution
+    resolution = INDEXED_DATA["data"]["CALCULATED"][IDENTIFIER]["date_resolution"][0]
+    # Ensure the date interval is in either months or days.
+    try:
+        resolution in ("month", "day")
+    except:
+        raise MappingError("No date_resolution found to specify date interval resolution: is there a date_resolution specified in the donor file?")
+    # Format as JSON, indicating interval resolution.
+    return {resolution + "_interval": single_val(data_values)}
 
 # Single date
 def single_date(data_values):

--- a/tests/raw_data/Donor.csv
+++ b/tests/raw_data/Donor.csv
@@ -1,7 +1,7 @@
 submitter_donor_id, program_id, lost_to_followup_after_clinical_event_identifier, lost_to_followup_reason, date_alive_after_lost_to_followup, is_deceased, cause_of_death, date_of_birth, date_of_death, gender, sex_at_birth, primary_site,date_resolution
-DONOR_1,TEST_1,,,,Yes,Died of cancer,6 Jan 1954,5/2020,Man,Male,Esophagus,month
-DONOR_2,TEST_1,,,,Yes,Died of other reasons,12 Feb 1982,6/20/2020,Woman,Female,Eye and adnexa,day
+DONOR_1,TEST_1,,,,Yes,Died of cancer,6 Jan 1954,35,Man,Male,Esophagus,month
+DONOR_2,TEST_1,,,,Yes,Died of other reasons,12 Feb 1982,239,Woman,Female,Eye and adnexa,day
 DONOR_3,TEST_1,PD_3,Lost contact,6/2022,No,,7/12/1945,,Non-binary,Other,Floor of mouth,month
-DONOR_4,TEST_1,,,,Yes,Unknown,6/1984,4/12/2020,Man,Male,Gallbladder,month
+DONOR_4,TEST_1,,,,Yes,Unknown,6/1984,239,Man,Male,Gallbladder,month
 DONOR_5,TEST_2,PD_5,Unknown,6/2022,Yes,,2/1984,,Woman,Female,Gum,month
 DONOR_6,TEST_2,PD_6,Withdrew from study,6/2022,No,,9/1974,,Non-binary,Other,"Heart, mediastinum, and pleura",month

--- a/tests/test2moh.csv
+++ b/tests/test2moh.csv
@@ -11,7 +11,7 @@ DONOR.INDEX.date_resolution, {single_val(Donor.date_resolution)}
 DONOR.INDEX.is_deceased, {boolean(Donor.is_deceased)}
 DONOR.INDEX.cause_of_death, {single_val(Donor.cause_of_death)}
 DONOR.INDEX.date_of_birth, {date_interval(Donor.date_of_birth)}
-DONOR.INDEX.date_of_death, {date_interval(Donor.date_of_death)}
+DONOR.INDEX.date_of_death, {int_to_date_interval_json(Donor.date_of_death)}
 DONOR.INDEX.gender, {single_val(Donor.gender)}
 DONOR.INDEX.sex_at_birth, {single_val(Donor.sex_at_birth)}
 DONOR.INDEX.primary_site, {pipe_delim(Donor.primary_site)}


### PR DESCRIPTION
Accept date intervals (+/- integers), given a specified date_resolution ("month" or "day").  Convert to JSON format to be stored in the DB.

Also corrects a bug in earliest_date() that arises if a non-indexed (non-list string) date field is defined in the manifest as the earliest_date.

mapping_functions.md updated accordingly. 