### PR TITLE
Improved documentation, validation and completeness summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Arrays of validation warnings and errors are found in `validation_warnings` & `v
 Summary statistics about the completeness of the objects against the schema are in the `statistics` key. You can create a readable CSV table
 of the summary statistics by running `completeness_table.py`. The table will be saved in `<INPUT_DIR>_completeness.csv`
 ```
-python src/clinical_etl/completeness_table.py <INPUT_DIR>_map.json
+python src/clinical_etl/completeness_table.py --input <INPUT_DIR>_map.json
 ```
 
 `<INPUT_DIR>_validation_results.json` contains all validation warnings and errors.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install -r requirements.txt
 >[!NOTE]
 > If Python can't find the `clinical_etl` module when running `CSVConvert`, install the depencency manually:
 > ```
-> pip install -e clinical_ETL_code
+> pip install -e clinical_ETL_code/
 > ```
 
 Before running the script, you will need to have your input files, this will be clinical data in a tabular format (`xlsx`/`csv`) that can be read into program and a cohort directory containing the files that define the schema and mapping configurations.
@@ -155,7 +155,7 @@ Validation will automatically be run after the conversion is complete. Any valid
 >[!NOTE]
 > If Python can't find the `clinical_etl` module when running `CSVConvert`, install the depencency manually:
 > ```
-> pip install -e clinical_ETL_code
+> pip install -e clinical_ETL_code/
 > ```
 
 #### Format of the output files

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ CSVConvert requires two inputs:
 2. a path to a `manifest.yml`, in a directory that also contains the other files defined in [Setting up a cohort directory](#Setting-up-a-cohort-directory)
 
 ```
-$ python src/clinical_etl/CSVConvert.py -h
+python src/clinical_etl/CSVConvert.py -h
 usage: CSVConvert.py [-h] --input INPUT --manifest MANIFEST [--test] [--verbose] [--index] [--minify]
 
 options:
@@ -162,12 +162,6 @@ Validation will automatically be run after the conversion is complete. Any valid
 
 `<INPUT_DIR>_map.json` is the main output and contains the results of the mapping, conversion and validation as well as summary statistics.
 
-The mapping and transformation result is found in the `"donors"` key.
-
-Arrays of validation warnings and errors are found in `validation_warnings` & `validation_errors`.
-
-Summary statistics about the completeness of the objects against the schema are in the `statistics` key.
-
 A summarised example of the output is below:
 
 ```json
@@ -201,6 +195,17 @@ A summarised example of the output is below:
     }
 }
 ```
+
+The mapping and transformation result is found in the `"donors"` key.
+
+Arrays of validation warnings and errors are found in `validation_warnings` & `validation_errors`.
+
+Summary statistics about the completeness of the objects against the schema are in the `statistics` key. You can create a readable CSV table
+of the summary statistics by running `completeness_table.py`. The table will be saved in `<INPUT_DIR>_completeness.csv`
+```
+python src/clinical_etl/completeness_table.py <INPUT_DIR>_map.json
+```
+
 `<INPUT_DIR>_validation_results.json` contains all validation warnings and errors.
 
 `<INPUT_DIR>_indexed.json` contains information about how the ETL is looking up the mappings and can be useful for debugging. It is only generated if the `--index` argument is specified when CSVConvert is run. Note: This file can be very large if the input data is large.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ pip install -r requirements.txt
 ```
 
 >[!NOTE]
-> If Python can't find the `clinical_ETL` module when running `CSVConvert`, install the depencency manually:
->```
->pip install -e clinical_ETL_code
-```
+> If Python can't find the `clinical_etl` module when running `CSVConvert`, install the depencency manually:
+> ```
+> pip install -e clinical_ETL_code
+> ```
 
 Before running the script, you will need to have your input files, this will be clinical data in a tabular format (`xlsx`/`csv`) that can be read into program and a cohort directory containing the files that define the schema and mapping configurations.
 
@@ -153,10 +153,10 @@ The main output `<INPUT_DIR>_map.json` and optional output`<INPUT_DIR>_indexed.j
 Validation will automatically be run after the conversion is complete. Any validation errors or warnings will be reported both on the command line and as part of the `<INPUT_DIR>_map.json` file.
 
 >[!NOTE]
-> If Python can't find the `clinical_ETL` module when running `CSVConvert`, install the depencency manually:
->```
->pip install -e clinical_ETL_code
->```
+> If Python can't find the `clinical_etl` module when running `CSVConvert`, install the depencency manually:
+> ```
+> pip install -e clinical_ETL_code
+> ```
 
 #### Format of the output files
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Set up and activate a [virtual environment](https://docs.python.org/3/tutorial/v
 python -m venv /path/to/new/virtual/environment
 source /path/to/new/virtual/environment/bin/activate
 ```
+
 [See here for Windows instructions](https://realpython.com/python-virtual-environments-a-primer/)
 
 Clone this repo and enter the repo directory
@@ -42,6 +43,12 @@ cd clinical_ETL_code
 Install the repo's requirements in your virtual environment
 ```commandline
 pip install -r requirements.txt
+```
+
+>[!NOTE]
+> If Python can't find the `clinical_ETL` module when running `CSVConvert`, install the depencency manually:
+>```
+>pip install -e clinical_ETL_code
 ```
 
 Before running the script, you will need to have your input files, this will be clinical data in a tabular format (`xlsx`/`csv`) that can be read into program and a cohort directory containing the files that define the schema and mapping configurations.
@@ -144,6 +151,12 @@ python src/clinical_etl/CSVConvert.py --input test_data/raw_data --manifest test
 The main output `<INPUT_DIR>_map.json` and optional output`<INPUT_DIR>_indexed.json` will be in the parent of the `INPUT` directory / file. In the example above, this would be in the `test_data` directory.
 
 Validation will automatically be run after the conversion is complete. Any validation errors or warnings will be reported both on the command line and as part of the `<INPUT_DIR>_map.json` file.
+
+>[!NOTE]
+> If Python can't find the `clinical_ETL` module when running `CSVConvert`, install the depencency manually:
+>```
+>pip install -e clinical_ETL_code
+>```
 
 #### Format of the output files
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The mapping and transformation result is found in the `"donors"` key.
 Arrays of validation warnings and errors are found in `validation_warnings` & `validation_errors`.
 
 Summary statistics about the completeness of the objects against the schema are in the `statistics` key. You can create a readable CSV table
-of the summary statistics by running `completeness_table.py`. The table will be saved in `<INPUT_DIR>_completeness.csv`
+of the summary statistics by running `completeness_table.py`. The table will be saved in `<INPUT_DIR>_completeness.csv`.
 ```
 python src/clinical_etl/completeness_table.py --input <INPUT_DIR>_map.json
 ```

--- a/src/clinical_etl/completeness_table.py
+++ b/src/clinical_etl/completeness_table.py
@@ -1,0 +1,33 @@
+import argparse
+import json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input", type=str, required=True, help="Path to input json file"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def generate_csv(input_path):
+    output_path = input_path.replace("json", "csv")
+    print(f"Converting {input_path} to {output_path}")
+    with open(input_path) as f:
+        summary_dict = json.load(f)
+        with open(output_path, "w") as out:
+            out.write("Schema,Field,Total,Missing,Fraction_missing\n")
+            required_but_missing = summary_dict["statistics"]["required_but_missing"]
+            for k, v in required_but_missing.items():
+                for field, stats in v.items():
+                    total = stats["total"]
+                    missing = stats["missing"]
+                    fraction = missing / total
+                    out.write(f"{k},{field},{total},{missing},{round(fraction,2)}\n")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    input_path = args.input
+    generate_csv(input_path)

--- a/src/clinical_etl/completeness_table.py
+++ b/src/clinical_etl/completeness_table.py
@@ -12,13 +12,13 @@ def parse_args():
 
 
 def generate_csv(input_path):
-    output_path = input_path.replace("json", "csv")
+    output_path = input_path.replace("_map.json", "_completeness.csv")
     print(f"Converting {input_path} to {output_path}")
     with open(input_path) as f:
-        summary_dict = json.load(f)
+        stats_dict = json.load(f)["statistics"]
         with open(output_path, "w") as out:
             out.write("Schema,Field,Total,Missing,Fraction_missing\n")
-            required_but_missing = summary_dict["statistics"]["required_but_missing"]
+            required_but_missing = stats_dict["required_but_missing"]
             for k, v in required_but_missing.items():
                 for field, stats in v.items():
                     total = stats["total"]

--- a/src/clinical_etl/mohschema.py
+++ b/src/clinical_etl/mohschema.py
@@ -262,7 +262,7 @@ class MoHSchema(BaseSchema):
                                     if ('diagnosis_date' in locals() and diagnosis_date not in [None, ''] and
                                             treatment_end not in [None, ''] and 'treatment_end' in locals() and
                                             treatment_end < diagnosis_date):
-                                        self.fail(f"{diagnosis['submitter_primary_diagnosis_id']} > {treatment['submitter_treatment_id']}: date_of_diagnosis must be earlier than treatment_end_date ")
+                                        self.warn(f"{diagnosis['submitter_primary_diagnosis_id']} > {treatment['submitter_treatment_id']}: date_of_diagnosis should be earlier than treatment_end_date ")
                                     if 'treatment_start' in locals() and treatment_start not in [None, '']:
                                         if 'death' in locals() and death not in [None, ''] and treatment_start > death:
                                             self.fail(
@@ -270,7 +270,7 @@ class MoHSchema(BaseSchema):
                                         if 'birth' in locals() and birth not in [None, ''] and treatment_start < birth and treatment_start is not None:
                                             self.fail(f"{diagnosis['submitter_primary_diagnosis_id']} > {treatment['submitter_treatment_id']}: treatment_start_date cannot be before date_of_birth")
                                         if 'diagnosis_date' in locals() and diagnosis_date not in [None, ''] and treatment_start < diagnosis_date:
-                                            self.fail(f"{diagnosis['submitter_primary_diagnosis_id']} > {treatment['submitter_treatment_id']}: treatment_start_date cannot be before date_of_diagnosis")
+                                            self.warn(f"{diagnosis['submitter_primary_diagnosis_id']} > {treatment['submitter_treatment_id']}: treatment_start_date should not be before date_of_diagnosis")
                         diagnosis_values_list = list(diagnoses_dates.values())
                         if (len(diagnosis_values_list) > 0 and "int" in str(type(diagnosis_values_list[0])) and
                                 0 not in diagnosis_values_list):


### PR DESCRIPTION
### What's new
- Added instructions to install the `clinical_etl` package into the virtual environment (if needed). [DIG-1613](https://candig.atlassian.net/browse/DIG-1613)
- If a treatment start or end date is earlier than date of diagnosis, return a validation warning instead of an error.
- Added `completeness_table.py` script written by @kcranston to generate a readable CSV file of the required field completeness stats.

### How to test
- `pip uninstall clinical_etl` from virtual environment, confirm that `CSVConvert` can't find the module, then reinstall with `pip install -e clinical_etl_code/` and confirm it does work.
- Create or validate a dataset with treatment start and end dates before date of diagnosis and check the warnings.
- Run `completeness_table.py` with any clinical `_map.json` file and check the output CSV file.

[DIG-1613]: https://candig.atlassian.net/browse/DIG-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ