### PR TITLE
update schema urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All rows must contain identifiers that allow linkage between the objects in the 
 
 Data should be [tidy](https://r4ds.had.co.nz/tidy-data.html), with each variable in a separate column, each row representing an observation, and a single data entry in each cell. In the case of fields that can accept an array of values, the values within a cell should be delimited such that a mapping function can accurately return an array of permissible values.
 
-If you are working with exports from RedCap, the sample files in the [`sample_inputs/redcap_example`](sample_inputs/redcap_example) folder may be helpful. 
+If you are working with exports from RedCap, the sample files in the [`sample_inputs/redcap_example`](sample_inputs/redcap_example) folder may be helpful.
 
 ### Setting up a cohort directory
 
@@ -172,7 +172,7 @@ A summarised example of the output is below:
 
 ```json
 {
-    "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml",
+    "openapi_url": "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml",
     "katsu_sha": < git sha of the katsu version used for the schema >,
     "donors": < An array of JSON objects, each one representing a DonorWithClinicalData in katsu >,
     "statistics": {

--- a/moh_v3_template.csv
+++ b/moh_v3_template.csv
@@ -1,4 +1,4 @@
-## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/mshadbolt/schema-field-ordering/chord_metadata_service/mohpackets/docs/schema.yml
+## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/mshadbolt/schema-field-ordering/chord_metadata_service/mohpackets/schemas/schema.yml
 ## Items are comma separated: element, mapping method
 DONOR.INDEX, {indexed_on(DONOR_SHEET.submitter_donor_id)}
 DONOR.INDEX.cause_of_death, {single_val(DONOR_SHEET.cause_of_death)}

--- a/sample_inputs/generic_example/manifest.yml
+++ b/sample_inputs/generic_example/manifest.yml
@@ -4,7 +4,7 @@ mapping: moh_template.csv
 # the name of the top-level identifier column in the input data
 identifier: submitter_donor_id
 # a link to the openapi schema
-schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml
+schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml
 # class of schema for validation:
 schema_class: MoHSchemaV3
 # a reference date used to calculate date intervals, formatted as a mapping entry for the mapping template

--- a/sample_inputs/generic_example/moh_template.csv
+++ b/sample_inputs/generic_example/moh_template.csv
@@ -1,4 +1,4 @@
-## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml
+## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml
 ## Based on repo commit sha "29fd55d173b7a01daa72fcc89187e3aabd1fb51e"
 ## MoH template is manually updated to match the MoH clinical data model
 ## Items are comma separated: element, mapping method

--- a/sample_inputs/redcap_example/manifest.yml
+++ b/sample_inputs/redcap_example/manifest.yml
@@ -1,6 +1,6 @@
 description: Test mapping of COMPARISON dataset to mCODEpacket format for katsu
 mapping: redcap2moh.csv
 identifier: submitter_donor_id
-schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml
+schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml
 functions:
     - redcap

--- a/sample_inputs/redcap_example/redcap2moh.csv
+++ b/sample_inputs/redcap_example/redcap2moh.csv
@@ -1,4 +1,4 @@
-## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml
+## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml
 ## Based on repo commit sha "29fd55d173b7a01daa72fcc89187e3aabd1fb51e"
 ## MoH template is manually updated to match the MoH clinical data model
 ## Items are comma separated: element, mapping method

--- a/src/clinical_etl/generate_schema.py
+++ b/src/clinical_etl/generate_schema.py
@@ -17,7 +17,7 @@ import re
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--url', type=str, help="URL to openAPI schema file (raw github link)", default="https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml")
+    parser.add_argument('--url', type=str, help="URL to openAPI schema file (raw github link)", default="https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml")
     parser.add_argument('--schema', type=str, help="Name of schema class", default="MoHSchemaV3")
     parser.add_argument('--out', type=str, help="name of output file; csv extension will be added. Default is template", default="template")
     args = parser.parse_args()

--- a/tests/manifest.yml
+++ b/tests/manifest.yml
@@ -1,7 +1,7 @@
 description: Test mapping
 mapping: test2mohv3.csv
 identifier: submitter_donor_id
-schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schema.yml
+schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/docs/schemas/schema.yml
 schema_class: MoHSchemaV3
 reference_date: earliest_date(Donor.date_resolution, PrimaryDiagnosis.date_of_diagnosis)
 date_format: DMY

--- a/tests/test2mohv3.csv
+++ b/tests/test2mohv3.csv
@@ -1,4 +1,4 @@
-## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/mshadbolt/schema-field-ordering/chord_metadata_service/mohpackets/docs/schema.yml
+## Schema generated from https://raw.githubusercontent.com/CanDIG/katsu/mshadbolt/schema-field-ordering/chord_metadata_service/mohpackets/schemas/schema.yml
 ## Items are comma separated: element, mapping method
 DONOR.INDEX, {indexed_on(Donor.submitter_donor_id)}
 DONOR.INDEX.cause_of_death, {single_val(Donor.cause_of_death)}


### PR DESCRIPTION
Now that the schema files have moved due to https://github.com/CanDIG/katsu/pull/265, we need to update the urls.