### PR TITLE
Date format only required for MoHSchema

### DIFF
--- a/sample_inputs/generic_example/manifest.yml
+++ b/sample_inputs/generic_example/manifest.yml
@@ -8,6 +8,7 @@ schema: https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_se
 # class of schema for validation:
 schema_class: MoHSchemaV3
 # a reference date used to calculate date intervals, formatted as a mapping entry for the mapping template
+date_format: DMY
 reference_date: earliest_date(Donor.date_resolution, PrimaryDiagnosis.date_of_diagnosis)
 # one or more files (dataset_functions.py) that implement the mappings
 # described in mapping file

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -649,7 +649,7 @@ def csv_convert(input_path, manifest_file, minify=False, index_output=False, ver
                  "see README for more details.")
     except TypeError as e:
         sys.exit("'identifier' in the manifest file cannot be blank, see README for more details.")
-    if manifest["schema_class_name"].starts_with("MoHSchema"):
+    if manifest["schema_class_name"].startswith("MoHSchema"):
         try:
             mappings.DATE_FORMAT = manifest["date_format"]
 

--- a/src/clinical_etl/CSVConvert.py
+++ b/src/clinical_etl/CSVConvert.py
@@ -589,6 +589,7 @@ def load_manifest(manifest_file):
         sys.exit("Need to specify an OpenAPI schema as 'schema' in the manifest file, "
                  "see README for more details.")
     if "schema_class" in manifest:
+        result["schema_class_name"]= manifest["schema_class"]
         schema_class = manifest["schema_class"]
 
     # programatically load schema class based on manifest value:
@@ -648,17 +649,19 @@ def csv_convert(input_path, manifest_file, minify=False, index_output=False, ver
                  "see README for more details.")
     except TypeError as e:
         sys.exit("'identifier' in the manifest file cannot be blank, see README for more details.")
-    try:
-        mappings.DATE_FORMAT = manifest["date_format"]
-        if manifest["date_format"] is None:
-            raise TypeError
-        if sorted(manifest["date_format"]) != sorted("DMY"):
-            raise TypeError
-    except KeyError as e:
-        sys.exit("'date_format' must be specified in the manifest file, see README for more details.")
-    except TypeError as e:
-        sys.exit("Need to specify a valid value for the date format in the manifest file, "
-                 "see README for more details.")
+    if manifest["schema_class_name"].starts_with("MoHSchema"):
+        try:
+            mappings.DATE_FORMAT = manifest["date_format"]
+
+            if manifest["date_format"] is None:
+                raise TypeError
+            if sorted(manifest["date_format"]) != sorted("DMY"):
+                raise TypeError
+        except KeyError as e:
+            sys.exit("'date_format' must be specified in the manifest file for MoHSchema, see README for more details.")
+        except TypeError as e:
+            sys.exit("Need to specify a valid value for the date format in the manifest file, "
+                     "see README for more details.")
 
     # read the schema (from the url specified in the manifest) and generate
     # a scaffold


### PR DESCRIPTION
Small fix so that only manifests that specify the MoH schema requires the date format argument