### PR TITLE
Year-only dates fix

### DIFF
--- a/src/clinical_etl/mappings.py
+++ b/src/clinical_etl/mappings.py
@@ -88,7 +88,11 @@ def _parse_date(date_string):
             _validate_date_format(date_string, DATE_FORMAT)
             d = dateparser.parse(
                 date_string,
-                settings={"PREFER_DAY_OF_MONTH": "first", "DATE_ORDER": DATE_FORMAT},
+                settings={
+                    "PREFER_DAY_OF_MONTH": "first", 
+                    "PREFER_MONTH_OF_YEAR": "first",
+                    "DATE_ORDER": DATE_FORMAT
+                },
             )
             return d.strftime("%Y-%m")
         except Exception as e:
@@ -157,7 +161,14 @@ def earliest_date(data_values):
     if len(dates_list) > 0:
         for date in dates_list:
             _validate_date_format(date, DATE_FORMAT)
-            d = dateparser.parse(date, settings={"PREFER_DAY_OF_MONTH": "first", "DATE_ORDER": DATE_FORMAT})
+            d = dateparser.parse(
+                date, 
+                settings={
+                    "PREFER_DAY_OF_MONTH": "first",
+                    "PREFER_MONTH_OF_YEAR": "first",
+                    "DATE_ORDER": DATE_FORMAT
+                    }
+            )
             if d < earliest:
                 earliest = d
         #print(f"The calculated earliest date is: {earliest.strftime("%Y-%m-%d")}")
@@ -185,7 +196,14 @@ def _date_interval(data_values, reference, date_format):
     if endpoint is None:
         return None
     offset = datetime.datetime.strptime(reference["offset"], "%Y-%m-%d")
-    date = dateparser.parse(endpoint, settings={"PREFER_DAY_OF_MONTH": "first", "DATE_ORDER": date_format})
+    date = dateparser.parse(
+        endpoint, 
+        settings={
+            "PREFER_DAY_OF_MONTH": "first",
+            "PREFER_MONTH_OF_YEAR": "first",
+            "DATE_ORDER": date_format,
+        }
+    )
     _validate_date_format(endpoint, date_format)
 
     is_neg = False

--- a/tests/test_mapping_functions.py
+++ b/tests/test_mapping_functions.py
@@ -7,22 +7,22 @@ from clinical_etl.mappings import _date_interval, MappingError
     "data_values, reference, date_format, expected",
     [
         (
-            {"date_of_birth": {"Donor": "5/1/1995"}},
+            {"date_of_birth": {"Donor": "5/2/2016"}},
             {"offset": "2018-05-01", "period": "month"},
             "MDY",
-            {"month_interval": -276},
+            {"month_interval": -23},
         ),
         (
-            {"date_of_birth": {"Donor": "5/1/1995"}},
+            {"date_of_birth": {"Donor": "5/2/2016"}},
             {"offset": "2018-05-01", "period": "day"},
             "MDY",
-            {"day_interval": -8401, "month_interval": -276},
+            {"day_interval": -729, "month_interval": -23},
         ),
         (
-            {"date_of_birth": {"Donor": "1/5/1995"}},
+            {"date_of_birth": {"Donor": "2/5/2016"}},
             {"offset": "2018-05-01", "period": "month"},
             "DMY",
-            {"month_interval": -276},
+            {"month_interval": -23},
         ),
         (
             {"date_of_diagnosis": {"PrimaryDiagnosis": "1/5/2018"}},
@@ -49,10 +49,10 @@ from clinical_etl.mappings import _date_interval, MappingError
             {"month_interval": 0},
         ),
         (
-            {"date_of_birth": {"Donor": "5/1/1995"}},
+            {"date_of_birth": {"Donor": "5/2/2016"}},
             {"offset": "2018-05-01", "period": "month"},
             "MDY",
-            {"month_interval": -276},
+            {"month_interval": -23},
         ),
         (
             {"specimen_collection_date": {"Specimens": "5/1/2021"}},
@@ -80,25 +80,28 @@ from clinical_etl.mappings import _date_interval, MappingError
         ),
         (
             {"specimen_collection_date": {"Specimens": "2021/5"}},
-            {"offset": "2018-05-15", "period": "month"},
+            {"offset": "2018-05-01", "period": "month"},
             "YMD",
-            {"month_interval": 35},
+            {"month_interval": 36},
         ),
         (
             {"specimen_collection_date": {"Specimens": "5/2021"}},
-            {"offset": "2018-05-15", "period": "month"},
+            {"offset": "2018-05-01", "period": "month"},
             "MYD",
-            {"month_interval": 35},
+            {"month_interval": 36},
         ),
         (
             {"specimen_collection_date": {"Specimens": "2021"}},
-            {"offset": "2018-05-15", "period": "month"},
+            {"offset": "2018-05-01", "period": "month"},
             "MYD",
-            {"month_interval": 34},
+            {"month_interval": 32},  # Picks the first month of the year
         ),
     ],
 )
 def test_valid_date_intervals(data_values, reference, date_format, expected):
+    print("data_values:", data_values)
+    print("reference:", reference)
+    print("interval:", _date_interval(data_values, reference, date_format))
     assert _date_interval(data_values, reference, date_format) == expected
 
 


### PR DESCRIPTION
- Specify the first month of the year in date parser when months are missing
- Update test intervals to confirm results more easily